### PR TITLE
Predefine family roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ High‑level Architecture
 	•	Upgrades/vehicles: techs (snow tires, larger tank, CB radio); minivan/pickup/bus with different stats.
 	•	Endings: reach a coast/territory; permadeath if resources hit zero during actions.
 
+## Family Roster
+
+The travelling party is a fixed family; all runs use the same six characters. Keep their relationships and ages in mind when
+writing events or dialogue:
+
+- Merri-Ellen — mom.
+- Mike — dad.
+- Ros — daughter, age 9.
+- Jess — daughter, age 6.
+- Martha — daughter, age 3.
+- Rusty — son, age 0.
+
+In code, each party member includes a `profile` field (`profile.familyRole`, `profile.age` where known) so event logic can tap
+into this metadata while the on-screen UI keeps ages/roles implicit.
+
 Files & Folders
 
 index.html

--- a/styles.css
+++ b/styles.css
@@ -229,14 +229,24 @@ legend {
   color: var(--color-text-muted);
 }
 
-.party-grid {
+.family-roster {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
   gap: var(--space-3);
 }
 
+.family-roster li {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  font-weight: 600;
+}
+
 @media (min-width: 720px) {
-  .party-grid {
-    grid-template-columns: repeat(3, 1fr);
+  .family-roster {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/systems/state.js
+++ b/systems/state.js
@@ -43,11 +43,65 @@ export const VEHICLES = [
   }
 ];
 
-const DEFAULT_PARTY = [
-  { name: 'Ava', role: 'Driver', health: 5, status: 'Ready' },
-  { name: 'Noah', role: 'Scout', health: 5, status: 'Peppy' },
-  { name: 'Maya', role: 'Mechanic', health: 5, status: 'Grease-free' }
+export const DEFAULT_PARTY = [
+  {
+    name: 'Merri-Ellen',
+    role: 'Trip captain',
+    health: 5,
+    status: 'Ready',
+    profile: { familyRole: 'mom' }
+  },
+  {
+    name: 'Mike',
+    role: 'Wheelman',
+    health: 5,
+    status: 'Ready',
+    profile: { familyRole: 'dad' }
+  },
+  {
+    name: 'Ros',
+    role: 'Trail spotter',
+    health: 5,
+    status: 'Ready',
+    profile: { familyRole: 'daughter', age: 9 }
+  },
+  {
+    name: 'Jess',
+    role: 'Snack scout',
+    health: 5,
+    status: 'Ready',
+    profile: { familyRole: 'daughter', age: 6 }
+  },
+  {
+    name: 'Martha',
+    role: 'Morale booster',
+    health: 5,
+    status: 'Ready',
+    profile: { familyRole: 'daughter', age: 3 }
+  },
+  {
+    name: 'Rusty',
+    role: 'Naptime mascot',
+    health: 5,
+    status: 'Ready',
+    profile: { familyRole: 'son', age: 0 }
+  }
 ];
+
+function instantiateDefaultParty() {
+  return DEFAULT_PARTY.map((member) => {
+    const { profile, ...rest } = member;
+    const clone = {
+      health: 5,
+      status: 'Ready',
+      ...rest
+    };
+    if (profile) {
+      clone.profile = { ...profile };
+    }
+    return clone;
+  });
+}
 
 const LOG_LIMIT = 40;
 
@@ -73,7 +127,7 @@ export class GameState {
     return Boolean(this.state);
   }
 
-  startNewRun({ seed, vehicleId, party }) {
+  startNewRun({ seed, vehicleId } = {}) {
     const vehicle = VEHICLES.find((entry) => entry.id === vehicleId) || VEHICLES[0];
     const resolvedSeed = Number.isInteger(seed) ? seed : Math.floor(Number(seed) || Date.now());
     this.rng = new RNG(resolvedSeed);
@@ -84,12 +138,7 @@ export class GameState {
       money: vehicle.stats.money
     };
     const maxResources = { ...resources };
-    const roster = (party && party.length ? party : DEFAULT_PARTY).map((member, index) => ({
-      name: member.name || DEFAULT_PARTY[index % DEFAULT_PARTY.length].name,
-      role: member.role || DEFAULT_PARTY[index % DEFAULT_PARTY.length].role,
-      health: member.health ?? 5,
-      status: member.status || 'Ready'
-    }));
+    const roster = instantiateDefaultParty();
 
     this.state = {
       version: 1,

--- a/tests/run.js
+++ b/tests/run.js
@@ -33,7 +33,7 @@ async function testSaveLoadRoundTrip() {
   })();
 
   const state = new GameState({ storage, storageKey: 'test-save' });
-  state.startNewRun({ seed: 999, vehicleId: 'minivan', party: [] });
+  state.startNewRun({ seed: 999, vehicleId: 'minivan' });
   const original = state.getSnapshot();
 
   const loaded = new GameState({ storage, storageKey: 'test-save' });

--- a/ui/SetupScreen.js
+++ b/ui/SetupScreen.js
@@ -1,10 +1,6 @@
-import { VEHICLES } from '../systems/state.js';
+import { VEHICLES, DEFAULT_PARTY } from '../systems/state.js';
 
-const PARTY_TEMPLATE = [
-  { id: 'leader', label: 'Driver', placeholder: 'Ava' },
-  { id: 'scout', label: 'Scout', placeholder: 'Noah' },
-  { id: 'mechanic', label: 'Mechanic', placeholder: 'Maya' }
-];
+const FAMILY_NAMES = DEFAULT_PARTY.map((member) => member.name);
 
 function generateSeed() {
   if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
@@ -31,8 +27,8 @@ export default class SetupScreen {
     const header = document.createElement('div');
     header.className = 'screen-header';
     header.innerHTML = `
-      <h2 id="setup-screen-heading">Dial in your rig and roster</h2>
-      <p>Choose a vehicle, lock in a seed, and rename your crew. Every selection shapes your Canadian odyssey.</p>
+      <h2 id="setup-screen-heading">Dial in your rig and seed</h2>
+      <p>Choose a vehicle, lock in a seed, and roll out with the family already buckled in.</p>
     `;
     section.append(header);
 
@@ -120,30 +116,20 @@ export default class SetupScreen {
     form.append(seedRow);
 
     const partyFieldset = document.createElement('fieldset');
-    partyFieldset.innerHTML = '<legend>Name your travelling party</legend>';
+    partyFieldset.innerHTML = '<legend>Family on board</legend>';
 
-    const partyGrid = document.createElement('div');
-    partyGrid.className = 'party-grid';
+    const partyIntro = document.createElement('p');
+    partyIntro.textContent = 'This crew is ready to roll:';
 
-    PARTY_TEMPLATE.forEach((member) => {
-      const wrapper = document.createElement('label');
-      wrapper.className = 'form-row';
-      wrapper.style.background = 'var(--color-surface-alt)';
-      wrapper.style.padding = 'var(--space-3)';
-      wrapper.style.borderRadius = 'var(--radius-md)';
-      wrapper.textContent = `${member.label}`;
-      const input = document.createElement('input');
-      input.type = 'text';
-      input.name = `party-${member.id}`;
-      input.placeholder = member.placeholder;
-      input.setAttribute('data-role', member.label);
-      input.maxLength = 16;
-      input.autocomplete = 'off';
-      wrapper.append(input);
-      partyGrid.append(wrapper);
+    const rosterList = document.createElement('ul');
+    rosterList.className = 'family-roster';
+    FAMILY_NAMES.forEach((name) => {
+      const item = document.createElement('li');
+      item.textContent = name;
+      rosterList.append(item);
     });
 
-    partyFieldset.append(partyGrid);
+    partyFieldset.append(partyIntro, rosterList);
     form.append(partyFieldset);
 
     const submit = document.createElement('button');
@@ -156,13 +142,7 @@ export default class SetupScreen {
       const formData = new FormData(form);
       const vehicleId = formData.get('vehicle');
       const seedValue = Number(formData.get('seed'));
-      const party = PARTY_TEMPLATE.map((member) => ({
-        name: String(formData.get(`party-${member.id}`) || member.placeholder),
-        role: member.label,
-        health: 5,
-        status: 'Ready'
-      }));
-      this.gameState.startNewRun({ seed: seedValue, vehicleId, party });
+      this.gameState.startNewRun({ seed: seedValue, vehicleId });
       this.screenManager.navigate('map');
     });
 


### PR DESCRIPTION
## Summary
- lock the default party to the fixed family roster with profile metadata for future events
- remove the setup form that renamed party members and display the ready-made crew instead
- document the family relationships in the README and adjust styles for the new roster list

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96b919e20832095ff5eca1ac1fd35