### PR TITLE
Revamp map screen with canvas viewport

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -73,6 +73,18 @@ body {
   outline: 3px solid #fff;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .site-header,
 .site-footer {
   padding: var(--space-5) var(--space-4) var(--space-3);
@@ -98,6 +110,23 @@ body {
 .site-footer {
   font-size: 0.875rem;
   color: var(--color-text-muted);
+}
+
+body.map-mode {
+  background: radial-gradient(120% 160% at 15% -10%, rgba(13, 60, 112, 0.4), rgba(3, 14, 30, 0.95) 45%, rgba(2, 8, 18, 1) 100%);
+  overflow: hidden;
+}
+
+body.map-mode main#app {
+  padding: 0;
+  width: 100vw;
+  height: 100vh;
+  align-items: stretch;
+}
+
+body.map-mode .site-header,
+body.map-mode .site-footer {
+  display: none;
 }
 
 main#app {
@@ -278,147 +307,320 @@ legend {
   }
 }
 
-.resource-board {
+
+.map-screen {
+  position: relative;
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border-radius: 0;
+  box-shadow: none;
+  background: radial-gradient(160% 120% at 15% -10%, rgba(20, 87, 152, 0.32), rgba(5, 20, 42, 0.92) 50%, rgba(3, 12, 26, 1) 90%);
+  color: #f4f8ff;
   display: grid;
-  gap: var(--space-3);
+  grid-template-rows: auto 1fr;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+  overflow: hidden;
+}
+
+.map-screen > * {
+  position: relative;
+  z-index: 1;
+}
+
+.map-screen::before {
+  content: '';
+  position: absolute;
+  inset: -60% -40% -30% -40%;
+  background: radial-gradient(60% 60% at 85% 5%, rgba(239, 108, 51, 0.24) 0%, transparent 55%),
+    radial-gradient(65% 60% at 25% 10%, rgba(123, 198, 255, 0.34) 0%, transparent 65%);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.map-topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1rem, 3vw, 2.5rem);
+  padding: clamp(1.25rem, 3vw, 2.5rem);
+  border-radius: calc(var(--radius-lg) * 1.05);
+  background: linear-gradient(150deg, rgba(6, 32, 62, 0.85), rgba(7, 55, 99, 0.72));
+  border: 1px solid rgba(144, 195, 255, 0.2);
+  box-shadow: 0 1.75rem 3.5rem rgba(4, 20, 40, 0.5);
+  backdrop-filter: blur(18px);
+}
+
+.map-heading {
+  max-width: min(32rem, 100%);
+}
+
+.map-heading h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: 0.01em;
+}
+
+.map-heading p {
+  margin: var(--space-2) 0 0;
+  max-width: 42ch;
+  color: rgba(233, 244, 255, 0.82);
+}
+
+.map-resources {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  flex: 1;
+  min-width: min(22rem, 100%);
 }
 
 .resource-track {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--space-3);
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: clamp(0.85rem, 2vw, 1.25rem);
   border-radius: var(--radius-md);
-  background: var(--color-surface-alt);
+  background: rgba(8, 36, 66, 0.85);
+  border: 1px solid rgba(144, 195, 255, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  color: #f5faff;
+  min-width: 0;
+}
+
+.resource-track span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(221, 236, 255, 0.78);
 }
 
 .resource-track strong {
-  font-size: 1.25rem;
+  font-size: 1.35rem;
+  color: #ffffff;
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
 }
 
 .resource-track strong small {
-  font-size: 0.75rem;
-  margin-left: var(--space-1);
-  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  color: rgba(221, 236, 255, 0.75);
   font-weight: 500;
 }
 
-.map-wrapper {
+.map-layout {
   display: grid;
-  gap: var(--space-4);
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 24rem);
+  gap: clamp(1.5rem, 4vw, 3rem);
+  height: 100%;
+  min-height: 0;
 }
 
-.map-area {
+.map-layout > * {
+  min-height: 0;
+}
+
+.map-stage {
   position: relative;
-  border: 2px solid rgba(8, 77, 140, 0.2);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(145deg, rgba(11, 109, 202, 0.05), rgba(239, 108, 51, 0.06));
-  padding: var(--space-4);
-  min-height: 360px;
+  border-radius: calc(var(--radius-lg) * 1.1);
   overflow: hidden;
+  min-height: clamp(320px, 55vh, 560px);
+  box-shadow: 0 2.5rem 4.5rem rgba(3, 12, 26, 0.68);
+  background: linear-gradient(160deg, rgba(3, 15, 32, 0.9), rgba(8, 38, 73, 0.85));
 }
 
-.map-area svg {
+.map-canvas {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
-  pointer-events: none;
+  display: block;
+}
+
+.map-node-layer {
+  position: absolute;
+  inset: 0;
 }
 
 .map-node {
   position: absolute;
-  width: 3.5rem;
-  height: 3.5rem;
+  transform: translate(-50%, -50%);
+  width: clamp(3rem, 4vw, 4.2rem);
+  height: clamp(3rem, 4vw, 4.2rem);
   border-radius: 50%;
-  border: 2px solid #fff;
-  box-shadow: 0 0.5rem 1.25rem rgba(12, 44, 73, 0.2);
   display: grid;
   place-items: center;
-  background: var(--color-primary);
-  color: #fff;
-  text-align: center;
-  padding: var(--space-2);
-  font-size: 0.75rem;
-  cursor: pointer;
-  transform: translate(-50%, -50%);
-  transition: transform var(--transition), background var(--transition);
-}
-
-.map-node[data-active="false"] {
-  background: var(--color-border);
-  color: var(--color-text-muted);
-  cursor: not-allowed;
-}
-
-.map-node[data-current="true"] {
-  background: var(--color-accent);
-}
-
-.map-node[disabled] {
-  pointer-events: none;
-  opacity: 0.6;
-}
-
-.location-details {
-  background: var(--color-surface-alt);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  display: grid;
-  gap: var(--space-2);
-}
-
-.location-details h3 {
-  margin: 0;
-  font-size: 1.25rem;
-}
-
-.location-details p {
-  margin: 0;
-  color: var(--color-text-muted);
-}
-
-.location-details ul {
-  list-style: disc;
-  margin: 0;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: var(--space-1);
-  color: var(--color-text);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: rgba(12, 69, 129, 0.92);
+  color: #f5f9ff;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  box-shadow: 0 1.5rem 2.5rem rgba(4, 20, 40, 0.48);
+  transition: transform var(--transition), background var(--transition), box-shadow var(--transition), border-color var(--transition);
+  backdrop-filter: blur(4px);
 }
 
 .map-node:hover,
 .map-node:focus-visible {
-  transform: translate(-50%, -52%) scale(1.02);
+  transform: translate(-50%, -55%) scale(1.05);
+  box-shadow: 0 2rem 3.5rem rgba(8, 45, 88, 0.55);
+  border-color: rgba(255, 255, 255, 0.9);
 }
 
-.log-panel {
-  border-radius: var(--radius-md);
-  background: var(--color-surface-alt);
-  padding: var(--space-4);
-  max-height: 12rem;
-  overflow-y: auto;
+.map-node[data-current="true"] {
+  background: linear-gradient(185deg, rgba(255, 215, 160, 0.95), rgba(239, 108, 51, 0.88));
+  color: #2f1500;
+  border-color: rgba(255, 245, 230, 0.9);
+  box-shadow: 0 2.25rem 3.75rem rgba(239, 108, 51, 0.52);
 }
 
-.log-panel h3 {
-  margin-top: 0;
-  font-size: 1rem;
+.map-node[data-reachable="true"] {
+  background: linear-gradient(180deg, rgba(84, 163, 255, 0.92), rgba(33, 113, 210, 0.9));
 }
 
-.log-panel ul {
+.map-node[data-visited="true"][data-current="false"] {
+  box-shadow: 0 1.5rem 3rem rgba(94, 142, 203, 0.35);
+}
+
+.map-node[data-active="false"] {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: rgba(255, 255, 255, 0.65);
+  box-shadow: none;
+}
+
+.map-node:disabled {
+  cursor: default;
+  background: rgba(255, 255, 255, 0.16);
+  color: rgba(255, 255, 255, 0.62);
+  opacity: 1;
+}
+
+.map-node-label {
+  pointer-events: none;
+}
+
+.map-sidebar {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  align-content: start;
+  min-height: 0;
+}
+
+.map-location,
+.map-log {
+  background: rgba(6, 28, 54, 0.78);
+  border-radius: calc(var(--radius-lg) * 0.9);
+  padding: clamp(1.25rem, 3vw, 2.5rem);
+  border: 1px solid rgba(144, 195, 255, 0.2);
+  box-shadow: 0 1.75rem 3.5rem rgba(4, 20, 40, 0.45);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: clamp(0.85rem, 2vw, 1.5rem);
+  min-height: 0;
+}
+
+.map-location-header h3 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+}
+
+.map-location-region {
+  margin: 0.35rem 0 0;
+  color: rgba(221, 236, 255, 0.75);
+  font-size: 0.95rem;
+}
+
+.map-section-label {
+  margin: 0;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(210, 228, 255, 0.72);
+}
+
+.map-action-section,
+.map-route-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.map-action-list,
+.map-route-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: var(--space-2);
+  gap: 0.75rem;
 }
 
-.log-panel li {
-  background: #fff;
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
+.map-action-list li,
+.map-route-list li {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(12, 48, 82, 0.62);
+  border: 1px solid rgba(144, 195, 255, 0.18);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.map-action-list li strong,
+.map-route-list li strong {
   font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(240, 248, 255, 0.92);
+}
+
+.map-action-list li span,
+.map-route-list li span {
+  font-size: 0.85rem;
+  color: rgba(226, 239, 255, 0.82);
+}
+
+.map-log h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 239, 255, 0.76);
+}
+
+.map-log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  max-height: clamp(12rem, 36vh, 17rem);
+  overflow-y: auto;
+}
+
+.map-log-list li {
+  background: rgba(9, 40, 72, 0.82);
+  border-radius: var(--radius-md);
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(144, 195, 255, 0.16);
+  font-size: 0.9rem;
+  color: rgba(228, 239, 255, 0.9);
+}
+
+.map-log-list::-webkit-scrollbar,
+.map-log::-webkit-scrollbar {
+  width: 0.6rem;
+}
+
+.map-log-list::-webkit-scrollbar-thumb,
+.map-log::-webkit-scrollbar-thumb {
+  background: rgba(133, 169, 220, 0.28);
+  border-radius: 999px;
 }
 
 .modal-backdrop {
@@ -458,12 +660,10 @@ legend {
   align-items: center;
 }
 
-.log-panel::-webkit-scrollbar,
 .modal::-webkit-scrollbar {
   width: 0.6rem;
 }
 
-.log-panel::-webkit-scrollbar-thumb,
 .modal::-webkit-scrollbar-thumb {
   background: rgba(12, 28, 44, 0.18);
   border-radius: 999px;
@@ -482,6 +682,52 @@ legend {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   image-rendering: pixelated;
+}
+
+@media (max-width: 1080px) {
+  .map-layout {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1fr) auto;
+  }
+
+  .map-sidebar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .map-screen {
+    padding: clamp(1rem, 5vw, 2rem);
+  }
+
+  .map-topbar {
+    flex-direction: column;
+  }
+
+  .map-resources {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .map-resources {
+    grid-template-columns: 1fr;
+  }
+
+  .map-stage {
+    min-height: clamp(260px, 62vh, 420px);
+  }
+}
+
+@media (max-height: 700px) {
+  .map-stage {
+    min-height: clamp(240px, 60vh, 420px);
+  }
+
+  .map-log-list {
+    max-height: clamp(9rem, 28vh, 12rem);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/ui/MapScreen.js
+++ b/ui/MapScreen.js
@@ -10,9 +10,19 @@ export default class MapScreen {
 
     this.section = null;
     this.resourceBoard = null;
+    this.stageElement = null;
+    this.mapCanvas = null;
+    this.mapContext = null;
     this.mapArea = null;
     this.logList = null;
     this.locationDetails = null;
+    this.a11yList = null;
+    this.activeConnections = [];
+    this.currentSnapshot = null;
+    this.stageSize = { width: 0, height: 0 };
+    this.resizeObserver = null;
+
+    this._handleKeydown = this._handleKeydown.bind(this);
   }
 
   bind() {}
@@ -22,11 +32,22 @@ export default class MapScreen {
       this.section = this._build();
     }
     this._refresh();
+    window.requestAnimationFrame(() => {
+      this._syncCanvasSize();
+    });
     return this.section;
   }
 
   activate() {
+    document.body.classList.add('map-mode');
     this._refresh();
+    this._syncCanvasSize();
+    document.addEventListener('keydown', this._handleKeydown);
+  }
+
+  deactivate() {
+    document.body.classList.remove('map-mode');
+    document.removeEventListener('keydown', this._handleKeydown);
   }
 
   _build() {
@@ -34,68 +55,83 @@ export default class MapScreen {
     section.className = 'screen map-screen';
     section.setAttribute('aria-labelledby', 'map-screen-heading');
 
-    const header = document.createElement('div');
-    header.className = 'screen-header';
-    header.innerHTML = `
+    const topbar = document.createElement('header');
+    topbar.className = 'map-topbar';
+
+    const headingGroup = document.createElement('div');
+    headingGroup.className = 'map-heading';
+    headingGroup.innerHTML = `
       <h2 id="map-screen-heading">Canadian Trail Atlas</h2>
-      <p>Plot your next hop across the provinces. Click an adjacent node to spend fuel, munch snacks, and advance the day.</p>
+      <p>Chart a single sweeping view of Canada. Focus a location to hear its details, then press Enter to travel.</p>
     `;
-    section.append(header);
+    topbar.append(headingGroup);
 
     this.resourceBoard = document.createElement('div');
-    this.resourceBoard.className = 'resource-board';
-    section.append(this.resourceBoard);
+    this.resourceBoard.className = 'map-resources';
+    topbar.append(this.resourceBoard);
 
-    const mapWrapper = document.createElement('div');
-    mapWrapper.className = 'map-wrapper';
+    section.append(topbar);
+
+    const layout = document.createElement('div');
+    layout.className = 'map-layout';
+
+    this.stageElement = document.createElement('div');
+    this.stageElement.className = 'map-stage';
+    this.stageElement.setAttribute('role', 'application');
+    this.stageElement.setAttribute('aria-label', 'Road map with travel nodes');
+
+    const instructions = document.createElement('p');
+    instructions.id = 'map-stage-instructions';
+    instructions.className = 'sr-only';
+    instructions.textContent = 'Use Tab to move between map locations. Press Enter or Space to travel to an available node.';
+    this.stageElement.setAttribute('aria-describedby', instructions.id);
+
+    const srConnections = document.createElement('ul');
+    srConnections.className = 'sr-only';
+    srConnections.id = 'map-stage-connections';
+    srConnections.setAttribute('aria-live', 'polite');
+    this.a11yList = srConnections;
+
+    this.mapCanvas = document.createElement('canvas');
+    this.mapCanvas.className = 'map-canvas';
+    this.mapCanvas.setAttribute('aria-hidden', 'true');
+    this.mapContext = this.mapCanvas.getContext('2d');
 
     this.mapArea = document.createElement('div');
-    this.mapArea.className = 'map-area';
-    this.mapArea.setAttribute('role', 'application');
-    this.mapArea.setAttribute('aria-label', 'Road map with travel nodes');
+    this.mapArea.className = 'map-node-layer';
 
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('viewBox', '0 0 100 60');
-    svg.setAttribute('aria-hidden', 'true');
-    this.mapArea.append(svg);
+    this.stageElement.append(instructions, srConnections, this.mapCanvas, this.mapArea);
 
-    this.locationDetails = document.createElement('div');
-    this.locationDetails.className = 'location-details';
+    layout.append(this.stageElement);
 
-    mapWrapper.append(this.mapArea, this.locationDetails);
-    section.append(mapWrapper);
+    const sidebar = document.createElement('aside');
+    sidebar.className = 'map-sidebar';
 
-    const logPanel = document.createElement('div');
-    logPanel.className = 'log-panel';
+    this.locationDetails = document.createElement('section');
+    this.locationDetails.className = 'map-location';
+    sidebar.append(this.locationDetails);
+
+    const logPanel = document.createElement('section');
+    logPanel.className = 'map-log';
     logPanel.innerHTML = '<h3>Road log</h3>';
     this.logList = document.createElement('ul');
+    this.logList.className = 'map-log-list';
     logPanel.append(this.logList);
-    section.append(logPanel);
+    sidebar.append(logPanel);
 
-    this._renderEdges(svg);
+    layout.append(sidebar);
+    section.append(layout);
+
     this._renderNodes();
 
-    return section;
-  }
+    if (!this.resizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => {
+        this._syncCanvasSize();
+      });
+    }
+    this.resizeObserver.observe(this.stageElement);
 
-  _renderEdges(svg) {
-    svg.innerHTML = '';
-    this.graph.edges.forEach((edge) => {
-      const from = this.graph.nodes.get(edge.from);
-      const to = this.graph.nodes.get(edge.to);
-      if (!from || !to) {
-        return;
-      }
-      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-      line.setAttribute('x1', from.coords.x);
-      line.setAttribute('y1', from.coords.y);
-      line.setAttribute('x2', to.coords.x);
-      line.setAttribute('y2', to.coords.y);
-      line.setAttribute('stroke', 'rgba(8, 77, 140, 0.4)');
-      line.setAttribute('stroke-width', '1.5');
-      line.setAttribute('stroke-linecap', 'round');
-      svg.append(line);
-    });
+    return section;
   }
 
   _renderNodes() {
@@ -109,7 +145,13 @@ export default class MapScreen {
       button.dataset.nodeId = node.id;
       button.style.left = `${node.coords.x}%`;
       button.style.top = `${node.coords.y}%`;
-      button.textContent = node.shortName || node.name;
+      button.setAttribute('aria-label', this._describeNode(node));
+      button.title = node.name;
+      const label = document.createElement('span');
+      label.className = 'map-node-label';
+      label.setAttribute('aria-hidden', 'true');
+      label.textContent = node.shortName || node.name;
+      button.append(label);
       button.addEventListener('click', () => {
         this._handleNodeClick(node.id);
       });
@@ -117,15 +159,226 @@ export default class MapScreen {
     });
   }
 
+  _syncCanvasSize() {
+    if (!this.stageElement || !this.mapCanvas) {
+      return;
+    }
+    const rect = this.stageElement.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+    const ratio = window.devicePixelRatio || 1;
+    const width = Math.round(rect.width * ratio);
+    const height = Math.round(rect.height * ratio);
+
+    if (this.mapCanvas.width !== width || this.mapCanvas.height !== height) {
+      this.mapCanvas.width = width;
+      this.mapCanvas.height = height;
+    }
+    this.mapCanvas.style.width = `${rect.width}px`;
+    this.mapCanvas.style.height = `${rect.height}px`;
+
+    if (this.mapContext) {
+      this.mapContext.setTransform(ratio, 0, 0, ratio, 0, 0);
+    }
+
+    this.stageSize = { width: rect.width, height: rect.height };
+    this._drawCanvas();
+  }
+
+  _drawCanvas() {
+    if (!this.mapContext || !this.stageSize.width || !this.stageSize.height) {
+      return;
+    }
+
+    const ctx = this.mapContext;
+    const { width, height } = this.stageSize;
+    ctx.clearRect(0, 0, width, height);
+
+    const background = ctx.createLinearGradient(0, 0, width, height);
+    background.addColorStop(0, '#05142a');
+    background.addColorStop(0.55, '#09335c');
+    background.addColorStop(1, '#0b6dca');
+    ctx.fillStyle = background;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.save();
+    const aurora = ctx.createLinearGradient(0, height * 0.12, width, height * 0.45);
+    aurora.addColorStop(0, 'rgba(123, 198, 255, 0.42)');
+    aurora.addColorStop(1, 'rgba(239, 108, 51, 0.35)');
+    ctx.fillStyle = aurora;
+    ctx.globalAlpha = 0.7;
+    ctx.beginPath();
+    ctx.moveTo(0, height * 0.18);
+    ctx.bezierCurveTo(width * 0.22, height * 0.05, width * 0.42, height * 0.32, width * 0.6, height * 0.18);
+    ctx.bezierCurveTo(width * 0.78, height * 0.08, width * 0.92, height * 0.2, width, height * 0.12);
+    ctx.lineTo(width, 0);
+    ctx.lineTo(0, 0);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = 'rgba(4, 22, 44, 0.6)';
+    ctx.beginPath();
+    ctx.moveTo(0, height * 0.72);
+    ctx.bezierCurveTo(width * 0.24, height * 0.6, width * 0.4, height * 0.88, width * 0.62, height * 0.78);
+    ctx.bezierCurveTo(width * 0.78, height * 0.7, width * 0.9, height * 0.92, width, height * 0.78);
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+
+    const highlightEdges = new Set();
+    if (this.currentSnapshot?.location && Array.isArray(this.activeConnections)) {
+      const currentId = this.currentSnapshot.location;
+      this.activeConnections.forEach((entry) => {
+        highlightEdges.add(this._edgeKey(currentId, entry.node.id));
+        highlightEdges.add(this._edgeKey(entry.node.id, currentId));
+      });
+    }
+
+    const drawn = new Set();
+    ctx.save();
+    ctx.lineCap = 'round';
+    ctx.globalAlpha = 0.55;
+    ctx.lineWidth = Math.max(1.6, width * 0.008);
+    this.graph.edges.forEach((edge) => {
+      const key = this._normalizedEdgeKey(edge.from, edge.to);
+      if (drawn.has(key)) {
+        return;
+      }
+      drawn.add(key);
+      const from = this.graph.nodes.get(edge.from);
+      const to = this.graph.nodes.get(edge.to);
+      if (!from || !to) {
+        return;
+      }
+      const fromPoint = this._toCanvasCoords(from.coords);
+      const toPoint = this._toCanvasCoords(to.coords);
+      const gradient = ctx.createLinearGradient(fromPoint.x, fromPoint.y, toPoint.x, toPoint.y);
+      gradient.addColorStop(0, 'rgba(138, 198, 255, 0.55)');
+      gradient.addColorStop(1, 'rgba(108, 158, 224, 0.45)');
+      ctx.strokeStyle = gradient;
+      ctx.beginPath();
+      ctx.moveTo(fromPoint.x, fromPoint.y);
+      ctx.lineTo(toPoint.x, toPoint.y);
+      ctx.stroke();
+    });
+    ctx.restore();
+
+    ctx.save();
+    ctx.lineCap = 'round';
+    const highlighted = new Set();
+    this.graph.edges.forEach((edge) => {
+      const key = this._normalizedEdgeKey(edge.from, edge.to);
+      if (highlighted.has(key)) {
+        return;
+      }
+      const forwardKey = this._edgeKey(edge.from, edge.to);
+      const backwardKey = this._edgeKey(edge.to, edge.from);
+      if (!highlightEdges.has(forwardKey) && !highlightEdges.has(backwardKey)) {
+        return;
+      }
+      highlighted.add(key);
+      const from = this.graph.nodes.get(edge.from);
+      const to = this.graph.nodes.get(edge.to);
+      if (!from || !to) {
+        return;
+      }
+      const fromPoint = this._toCanvasCoords(from.coords);
+      const toPoint = this._toCanvasCoords(to.coords);
+      ctx.strokeStyle = 'rgba(255, 214, 153, 0.9)';
+      ctx.lineWidth = Math.max(3, width * 0.012);
+      ctx.shadowColor = 'rgba(255, 199, 120, 0.6)';
+      ctx.shadowBlur = Math.max(18, width * 0.05);
+      ctx.beginPath();
+      ctx.moveTo(fromPoint.x, fromPoint.y);
+      ctx.lineTo(toPoint.x, toPoint.y);
+      ctx.stroke();
+    });
+    ctx.restore();
+
+    ctx.save();
+    this.graph.nodes.forEach((node) => {
+      const point = this._toCanvasCoords(node.coords);
+      const isCurrent = this.currentSnapshot?.location === node.id;
+      const isReachable = this.activeConnections?.some((entry) => entry.node.id === node.id);
+      const visited = this.currentSnapshot?.visited?.includes(node.id);
+      const base = Math.max(width, height);
+      const radius = isCurrent ? base * 0.06 : isReachable ? base * 0.045 : base * 0.035;
+      const gradient = ctx.createRadialGradient(point.x, point.y, 0, point.x, point.y, radius);
+      if (isCurrent) {
+        gradient.addColorStop(0, 'rgba(255, 233, 179, 0.95)');
+        gradient.addColorStop(0.5, 'rgba(255, 199, 120, 0.6)');
+        gradient.addColorStop(1, 'rgba(255, 199, 120, 0)');
+      } else if (isReachable) {
+        gradient.addColorStop(0, 'rgba(123, 198, 255, 0.9)');
+        gradient.addColorStop(1, 'rgba(123, 198, 255, 0)');
+      } else if (visited) {
+        gradient.addColorStop(0, 'rgba(255, 255, 255, 0.35)');
+        gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+      } else {
+        gradient.addColorStop(0, 'rgba(94, 142, 203, 0.22)');
+        gradient.addColorStop(1, 'rgba(94, 142, 203, 0)');
+      }
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    ctx.restore();
+  }
+
+  _edgeKey(from, to) {
+    return `${from}::${to}`;
+  }
+
+  _normalizedEdgeKey(from, to) {
+    return [from, to].sort().join('::');
+  }
+
+  _toCanvasCoords(coords = { x: 0, y: 0 }) {
+    const { width, height } = this.stageSize;
+    if (!width || !height) {
+      return { x: 0, y: 0 };
+    }
+    const x = ((coords.x ?? 0) / 100) * width;
+    const y = ((coords.y ?? 0) / 100) * height;
+    return { x, y };
+  }
+
+  _describeNode(node) {
+    if (!node) {
+      return '';
+    }
+    const segments = [node.name];
+    if (node.region) {
+      segments.push(`Region: ${node.region}`);
+    }
+    if (Array.isArray(node.actions) && node.actions.length) {
+      const actionNames = node.actions
+        .map((action) => this._describeAction(action).title)
+        .join(', ');
+      if (actionNames) {
+        segments.push(`Camp options: ${actionNames}`);
+      }
+    }
+    return segments.join('. ');
+  }
+
   _refresh() {
     const snapshot = this.gameState.getSnapshot();
     if (!snapshot) {
       return;
     }
+    this.currentSnapshot = snapshot;
     this._updateResourceBoard(snapshot);
     this._updateNodes(snapshot);
     this._updateLocation(snapshot);
     this._updateLog(snapshot);
+    this._drawCanvas();
   }
 
   _updateResourceBoard(snapshot) {
@@ -156,6 +409,8 @@ export default class MapScreen {
     const currentId = snapshot.location;
     const activeConnections = getConnections(this.graph, currentId);
     const activeIds = new Set([currentId, ...activeConnections.map((entry) => entry.node.id)]);
+    const visitedIds = new Set(Array.isArray(snapshot.visited) ? snapshot.visited : []);
+    this.activeConnections = activeConnections;
 
     this.mapArea.querySelectorAll('.map-node').forEach((button) => {
       const nodeId = button.dataset.nodeId;
@@ -163,8 +418,42 @@ export default class MapScreen {
       button.dataset.current = String(isCurrent);
       const isActive = activeIds.has(nodeId);
       button.dataset.active = String(isActive);
-      button.disabled = !isActive || isCurrent;
+      button.dataset.reachable = String(isActive && !isCurrent);
+      button.dataset.visited = String(visitedIds.has(nodeId));
+      button.disabled = !isActive;
+      if (isCurrent) {
+        button.setAttribute('aria-current', 'true');
+      } else {
+        button.removeAttribute('aria-current');
+      }
     });
+
+    if (this.a11yList) {
+      this.a11yList.innerHTML = '';
+      const currentNode = this.graph.nodes.get(currentId);
+      if (currentNode) {
+        const currentItem = document.createElement('li');
+        const region = currentNode.region ? ` in ${currentNode.region}` : '';
+        currentItem.textContent = `Current location: ${currentNode.name}${region}.`;
+        this.a11yList.append(currentItem);
+      }
+
+      if (activeConnections.length) {
+        activeConnections.forEach((entry) => {
+          const { node, link } = entry;
+          const gasCost = Math.max(1, Math.round(link?.distance || 1));
+          const region = node.region ? ` in ${node.region}` : '';
+          const roughText = link?.rough ? ' via a rough road' : '';
+          const item = document.createElement('li');
+          item.textContent = `Route to ${node.name}${region} costs ${gasCost} fuel${roughText}.`;
+          this.a11yList.append(item);
+        });
+      } else {
+        const noRoutes = document.createElement('li');
+        noRoutes.textContent = 'No reachable destinations from this location yet.';
+        this.a11yList.append(noRoutes);
+      }
+    }
   }
 
   _updateLocation(snapshot) {
@@ -174,23 +463,93 @@ export default class MapScreen {
     }
     this.locationDetails.innerHTML = '';
 
+    const header = document.createElement('div');
+    header.className = 'map-location-header';
+
     const title = document.createElement('h3');
     title.textContent = node.name;
-    this.locationDetails.append(title);
+    header.append(title);
 
     const region = document.createElement('p');
+    region.className = 'map-location-region';
     region.textContent = node.region || 'Somewhere along the Trans-Canada';
-    this.locationDetails.append(region);
+    header.append(region);
+
+    this.locationDetails.append(header);
 
     if (Array.isArray(node.actions) && node.actions.length) {
+      const actionSection = document.createElement('div');
+      actionSection.className = 'map-action-section';
+
+      const actionLabel = document.createElement('p');
+      actionLabel.className = 'map-section-label';
+      actionLabel.textContent = 'Camp options';
+      actionSection.append(actionLabel);
+
       const actionList = document.createElement('ul');
+      actionList.className = 'map-action-list';
       actionList.setAttribute('aria-label', 'Available actions');
       node.actions.forEach((action) => {
+        const { title: actionTitle, description } = this._describeAction(action);
         const li = document.createElement('li');
-        li.textContent = this._describeAction(action);
+        const strong = document.createElement('strong');
+        strong.textContent = actionTitle;
+        li.append(strong);
+        if (description) {
+          const span = document.createElement('span');
+          span.textContent = description;
+          li.append(span);
+        }
         actionList.append(li);
       });
-      this.locationDetails.append(actionList);
+      actionSection.append(actionList);
+      this.locationDetails.append(actionSection);
+    }
+
+    if (this.activeConnections.length) {
+      const routeSection = document.createElement('div');
+      routeSection.className = 'map-route-section';
+
+      const routeLabel = document.createElement('p');
+      routeLabel.className = 'map-section-label';
+      routeLabel.textContent = 'Reachable routes';
+      routeSection.append(routeLabel);
+
+      const routeList = document.createElement('ul');
+      routeList.className = 'map-route-list';
+      routeList.setAttribute('aria-label', 'Reachable destinations');
+
+      this.activeConnections.forEach((entry) => {
+        const { node: nextNode, link } = entry;
+        const li = document.createElement('li');
+
+        const heading = document.createElement('strong');
+        heading.textContent = nextNode.name;
+        li.append(heading);
+
+        const metaBits = [];
+        if (link?.label) {
+          metaBits.push(link.label);
+        }
+        if (link?.distance) {
+          const gasCost = Math.max(1, Math.round(link.distance));
+          metaBits.push(`${gasCost} fuel`);
+        }
+        if (link?.rough) {
+          metaBits.push('Rough road');
+        }
+
+        if (metaBits.length) {
+          const detail = document.createElement('span');
+          detail.textContent = metaBits.join(' • ');
+          li.append(detail);
+        }
+
+        routeList.append(li);
+      });
+
+      routeSection.append(routeList);
+      this.locationDetails.append(routeSection);
     }
   }
 
@@ -210,17 +569,35 @@ export default class MapScreen {
   _describeAction(action) {
     switch (action) {
       case 'siphon':
-        return 'Siphon: Trade time for gas at risk of fumes.';
+        return {
+          title: 'Siphon',
+          description: 'Trade time for gas at risk of fumes.'
+        };
       case 'forage':
-        return 'Forage: Scout nearby forests for berries and jerky.';
+        return {
+          title: 'Forage',
+          description: 'Scout nearby forests for berries and jerky.'
+        };
       case 'tinker':
-        return 'Tinker: Repair the ride with spare parts and elbow grease.';
+        return {
+          title: 'Tinker',
+          description: 'Repair the ride with spare parts and elbow grease.'
+        };
       case 'ferry':
-        return 'Ferry: Pay a toll to cross water safely.';
+        return {
+          title: 'Ferry',
+          description: 'Pay a toll to cross water safely.'
+        };
       case 'town':
-        return 'Town: Visit shops and upgrade stands (coming soon).';
+        return {
+          title: 'Town',
+          description: 'Visit shops and upgrade stands (coming soon).'
+        };
       default:
-        return action;
+        return {
+          title: action.charAt(0).toUpperCase() + action.slice(1),
+          description: ''
+        };
     }
   }
 
@@ -262,6 +639,33 @@ export default class MapScreen {
         }
       });
     }
+  }
+
+  _handleKeydown(event) {
+    if (!['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
+      return;
+    }
+    if (!this.section || !this.mapArea) {
+      return;
+    }
+    if (!this.section.contains(document.activeElement)) {
+      return;
+    }
+    const focusableNodes = Array.from(this.mapArea.querySelectorAll('.map-node:not([disabled])'));
+    if (!focusableNodes.length) {
+      return;
+    }
+    const currentIndex = focusableNodes.indexOf(document.activeElement);
+    let targetIndex;
+    if (currentIndex === -1) {
+      targetIndex = 0;
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      targetIndex = (currentIndex + 1) % focusableNodes.length;
+    } else {
+      targetIndex = (currentIndex - 1 + focusableNodes.length) % focusableNodes.length;
+    }
+    focusableNodes[targetIndex].focus();
+    event.preventDefault();
   }
 
   _resolveEventChoice(event, choice) {


### PR DESCRIPTION
## Summary
- rebuild the map screen as a full-viewport experience with a11y overlays and keyboard navigation
- render the road network and node glows on a responsive canvas that reacts to game state
- refresh styling for the immersive map mode, resource chips, and sidebar panels while hiding page chrome during play

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9898b61f48320a561ed630f940d41