### PR TITLE
Refactor world progression to generated checkpoints and actions

### DIFF
--- a/data/world.json
+++ b/data/world.json
@@ -1,0 +1,69 @@
+{
+  "worldVersion": 2,
+  "checkpoints": [
+    {
+      "id": "halifax-hub",
+      "name": "Halifax Harbour",
+      "shortName": "Halifax",
+      "coords": { "x": 10, "y": 52 },
+      "region": "Nova Scotia",
+      "actions": ["shop", "ferry"]
+    },
+    {
+      "id": "quebec-mechanic",
+      "name": "Quebec City Overlook",
+      "shortName": "Quebec",
+      "coords": { "x": 24, "y": 46 },
+      "region": "Quebec",
+      "actions": ["shop", "tinker"]
+    },
+    {
+      "id": "ottawa-town",
+      "name": "Ottawa Market Row",
+      "shortName": "Ottawa",
+      "coords": { "x": 38, "y": 48 },
+      "region": "Ontario",
+      "actions": ["shop", "tinker"]
+    },
+    {
+      "id": "thunder-bay",
+      "name": "Thunder Bay Marina",
+      "shortName": "Thunder",
+      "coords": { "x": 52, "y": 42 },
+      "region": "Lake Superior Shore",
+      "actions": ["shop", "tinker"]
+    },
+    {
+      "id": "winnipeg-crossing",
+      "name": "Winnipeg Prairie Crossing",
+      "shortName": "Winnipeg",
+      "coords": { "x": 64, "y": 50 },
+      "region": "Manitoba",
+      "actions": ["shop", "tinker"]
+    },
+    {
+      "id": "regina-plains",
+      "name": "Regina Grassland Gate",
+      "shortName": "Regina",
+      "coords": { "x": 74, "y": 44 },
+      "region": "Saskatchewan",
+      "actions": ["shop", "scavenge"]
+    },
+    {
+      "id": "calgary-foothills",
+      "name": "Calgary Foothills Plaza",
+      "shortName": "Calgary",
+      "coords": { "x": 84, "y": 42 },
+      "region": "Alberta",
+      "actions": ["shop", "tinker"]
+    },
+    {
+      "id": "vancouver-terminal",
+      "name": "Vancouver Coastal Terminal",
+      "shortName": "Vancouver",
+      "coords": { "x": 92, "y": 54 },
+      "region": "British Columbia",
+      "actions": ["shop", "ferry"]
+    }
+  ]
+}

--- a/main.js
+++ b/main.js
@@ -1,5 +1,4 @@
 import { GameState } from './systems/state.js';
-import { loadGraph } from './systems/graph.js';
 import { EventEngine } from './systems/events.js';
 import TitleScreen from './ui/TitleScreen.js';
 import SetupScreen from './ui/SetupScreen.js';
@@ -55,7 +54,6 @@ async function bootstrap() {
   const eventEngine = new EventEngine();
   await eventEngine.initialize();
 
-  const graph = await loadGraph();
   const eventModal = new EventModal(document.body);
 
   const titleScreen = new TitleScreen({ screenManager, gameState });
@@ -63,7 +61,6 @@ async function bootstrap() {
   const mapScreen = new MapScreen({
     screenManager,
     gameState,
-    graph,
     eventEngine,
     eventModal
   });

--- a/styles.css
+++ b/styles.css
@@ -447,6 +447,126 @@ legend {
   inset: 0;
 }
 
+
+.map-preview {
+  position: absolute;
+  left: clamp(0.8rem, 2.5vw, 1.6rem);
+  bottom: clamp(0.8rem, 2.5vw, 1.6rem);
+  width: min(280px, 72%);
+  padding: clamp(0.85rem, 2vw, 1.35rem);
+  border-radius: var(--radius-md);
+  background: rgba(6, 28, 54, 0.9);
+  border: 1px solid rgba(144, 195, 255, 0.28);
+  box-shadow: 0 1.65rem 3.5rem rgba(4, 20, 40, 0.58);
+  backdrop-filter: blur(12px);
+  transition: opacity var(--transition), transform var(--transition);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(0.75rem);
+  display: grid;
+  gap: 0.5rem;
+  z-index: 5;
+}
+
+.map-preview[data-visible="true"] {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.map-preview-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(240, 248, 255, 0.95);
+}
+
+.map-preview-stats {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+}
+
+.map-preview-stats dt {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(221, 236, 255, 0.72);
+}
+
+.map-preview-stats dd {
+  margin: 0;
+  color: rgba(240, 249, 255, 0.92);
+  font-weight: 600;
+}
+
+.map-preview-yields {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.map-preview-yields p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(226, 239, 255, 0.82);
+}
+
+.map-preview-yields p strong {
+  color: rgba(240, 248, 255, 0.92);
+  font-weight: 600;
+}
+
+.map-location-conditions {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(210, 228, 255, 0.75);
+}
+
+.map-action-feedback {
+  margin: 0;
+  min-height: 1.2rem;
+  font-size: 0.82rem;
+  color: rgba(240, 248, 255, 0.8);
+}
+
+.map-action-list li {
+  gap: 0.6rem;
+}
+
+.map-action-list li button {
+  justify-self: start;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: var(--radius-sm);
+  background: rgba(16, 78, 136, 0.85);
+  border: 1px solid rgba(144, 195, 255, 0.38);
+  box-shadow: none;
+}
+
+.map-action-list li button:hover,
+.map-action-list li button:focus-visible {
+  background: rgba(28, 104, 176, 0.95);
+}
+
+.map-action-list li small {
+  font-size: 0.75rem;
+  color: rgba(200, 224, 255, 0.7);
+}
+
+.map-action-warning {
+  color: rgba(255, 202, 143, 0.92);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+
 .map-node {
   position: absolute;
   transform: translate(-50%, -50%);

--- a/systems/graph.js
+++ b/systems/graph.js
@@ -1,24 +1,33 @@
 import { loadJSON } from './jsonLoader.js';
 
-let cachedGraph = null;
+let cachedLegacyGraph = null;
 
 function normalizeConnections(entries = []) {
   return entries.map((entry) => {
     if (typeof entry === 'string') {
-      return { id: entry, distance: 1, rough: false };
+      return { id: entry, distance: 1, rough: false, roughness: 1, hazard: 0.15, label: null };
     }
+    const distance = typeof entry.distance === 'number' ? entry.distance : 1;
+    const roughness = typeof entry.roughness === 'number'
+      ? entry.roughness
+      : entry.rough
+        ? 1.3
+        : 1;
+    const hazard = typeof entry.hazard === 'number' ? entry.hazard : entry.rough ? 0.45 : 0.2;
     return {
       id: entry.id,
-      distance: typeof entry.distance === 'number' ? entry.distance : 1,
-      rough: Boolean(entry.rough),
+      distance,
+      rough: Boolean(entry.rough || roughness > 1.15),
+      roughness,
+      hazard,
       label: entry.label || null
     };
   });
 }
 
-export async function loadGraph() {
-  if (cachedGraph) {
-    return cachedGraph;
+export async function loadLegacyGraph() {
+  if (cachedLegacyGraph) {
+    return cachedLegacyGraph;
   }
   const data = await loadJSON('../data/nodes.json');
   const nodes = new Map();
@@ -34,16 +43,18 @@ export async function loadGraph() {
       edges.push({ from: node.id, to: connection.id });
     });
   });
-  cachedGraph = {
+  cachedLegacyGraph = {
     start: data.start || list[0]?.id || 'halifax-hub',
     nodes,
     edges
   };
-  return cachedGraph;
+  return cachedLegacyGraph;
 }
 
+export const loadGraph = loadLegacyGraph;
+
 export function getConnections(graph, nodeId) {
-  const node = graph.nodes.get(nodeId);
+  const node = graph?.nodes?.get ? graph.nodes.get(nodeId) : null;
   if (!node) {
     return [];
   }

--- a/systems/jsonLoader.js
+++ b/systems/jsonLoader.js
@@ -1,8 +1,17 @@
 export async function loadJSON(path) {
   const url = new URL(path, import.meta.url);
-  const response = await fetch(url, { cache: 'no-store' });
-  if (!response.ok) {
-    throw new Error(`Failed to load JSON at ${path}: ${response.status}`);
+  try {
+    const response = await fetch(url, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Failed to load JSON at ${path}: ${response.status}`);
+    }
+    return response.json();
+  } catch (error) {
+    if (url.protocol === 'file:' && typeof process !== 'undefined') {
+      const { readFile } = await import('node:fs/promises');
+      const data = await readFile(url, 'utf-8');
+      return JSON.parse(data);
+    }
+    throw error;
   }
-  return response.json();
 }

--- a/systems/nodeActions.js
+++ b/systems/nodeActions.js
@@ -1,0 +1,306 @@
+import { createDerivedRNG } from './rng.js';
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizeRange(range, defaults = { min: 0, max: 0 }) {
+  const resolvedMin = Number.isFinite(range?.min) ? range.min : defaults.min ?? 0;
+  const resolvedMax = Number.isFinite(range?.max) ? range.max : defaults.max ?? resolvedMin;
+  const min = Math.max(0, Math.round(resolvedMin));
+  const max = Math.max(min, Math.round(resolvedMax));
+  return { min, max };
+}
+
+function pickInt(rng, range) {
+  return rng.nextInt(range.min, range.max);
+}
+
+function computeFerryCost(profile) {
+  const base = profile?.services?.ferryCost ?? 4;
+  return Math.max(1, Math.round(base));
+}
+
+function computeShopCost(profile) {
+  const serviceCost = profile?.services?.shopCost;
+  if (Number.isFinite(serviceCost)) {
+    return Math.max(1, Math.round(serviceCost));
+  }
+  const prosperity = clamp(profile?.prosperity ?? 0.5, 0, 1);
+  return Math.max(2, Math.round(3 + prosperity * 3));
+}
+
+const ACTION_DEFINITIONS = {
+  siphon: {
+    id: 'siphon',
+    title: 'Siphon',
+    description: 'Trade time for gas at risk of fumes.',
+    preview(node) {
+      const gasRange = normalizeRange(node?.profile?.yields?.gas, { min: 1, max: 3 });
+      const hazard = clamp(node?.profile?.hazard ?? 0.2, 0, 1);
+      const rideMax = hazard > 0.7 ? 2 : hazard > 0.45 ? 1 : 0;
+      return {
+        id: 'siphon',
+        title: this.title,
+        description: this.description,
+        yields: [{ resource: 'gas', min: gasRange.min, max: gasRange.max }],
+        costs: [],
+        mishaps: rideMax ? [{ resource: 'ride', min: 0, max: rideMax }] : [],
+        timeCost: 1
+      };
+    },
+    roll(node, rng) {
+      const gasRange = normalizeRange(node?.profile?.yields?.gas, { min: 1, max: 3 });
+      const gasGain = pickInt(rng, gasRange);
+      const hazard = clamp(node?.profile?.hazard ?? 0.2, 0, 1);
+      const mishapChance = Math.min(0.85, hazard + 0.15);
+      let rideDamage = 0;
+      if (mishapChance > 0 && rng.nextFloat() < mishapChance) {
+        rideDamage = hazard > 0.75 ? 2 : 1;
+        if (hazard > 0.9 && rng.nextFloat() < 0.35) {
+          rideDamage += 1;
+        }
+      }
+      const parts = [`Siphoned ${gasGain} gas`];
+      if (rideDamage > 0) {
+        parts.push(`ride -${rideDamage}`);
+      }
+      return {
+        deltas: { gas: gasGain, snacks: 0, ride: -rideDamage, money: 0 },
+        timeCost: 1,
+        message: `${parts.join(', ')}.`
+      };
+    }
+  },
+  forage: {
+    id: 'forage',
+    title: 'Forage',
+    description: 'Scout nearby forests for berries and jerky.',
+    preview(node) {
+      const snackRange = normalizeRange(node?.profile?.yields?.snacks, { min: 1, max: 4 });
+      const hazard = clamp(node?.profile?.hazard ?? 0.15, 0, 1);
+      const rideMax = hazard > 0.55 ? 1 : 0;
+      return {
+        id: 'forage',
+        title: this.title,
+        description: this.description,
+        yields: [{ resource: 'snacks', min: snackRange.min, max: snackRange.max }],
+        costs: [],
+        mishaps: rideMax ? [{ resource: 'ride', min: 0, max: rideMax }] : [],
+        timeCost: 1
+      };
+    },
+    roll(node, rng) {
+      const snackRange = normalizeRange(node?.profile?.yields?.snacks, { min: 1, max: 4 });
+      const snackGain = pickInt(rng, snackRange);
+      const hazard = clamp(node?.profile?.hazard ?? 0.15, 0, 1);
+      let rideDamage = 0;
+      if (hazard > 0.4 && rng.nextFloat() < hazard / 2) {
+        rideDamage = 1;
+      }
+      let bonusGas = 0;
+      const abundance = clamp(node?.profile?.abundance ?? 0.4, 0, 1);
+      if (rng.nextFloat() < abundance * 0.3) {
+        bonusGas = 1;
+      }
+      const parts = [`Foraged ${snackGain} snacks`];
+      if (bonusGas > 0) {
+        parts.push(`found ${bonusGas} gas can`);
+      }
+      if (rideDamage > 0) {
+        parts.push('scrapes cost 1 ride');
+      }
+      return {
+        deltas: { gas: bonusGas, snacks: snackGain, ride: -rideDamage, money: 0 },
+        timeCost: 1,
+        message: `${parts.join(', ')}.`
+      };
+    }
+  },
+  tinker: {
+    id: 'tinker',
+    title: 'Tinker',
+    description: 'Repair the ride with spare parts and elbow grease.',
+    preview(node) {
+      const rideRange = normalizeRange(node?.profile?.yields?.ride, { min: 1, max: 3 });
+      const gasCost = node?.profile?.services?.mechanic ? 1 : 2;
+      return {
+        id: 'tinker',
+        title: this.title,
+        description: this.description,
+        yields: [{ resource: 'ride', min: rideRange.min, max: rideRange.max }],
+        costs: gasCost ? [{ resource: 'gas', amount: gasCost }] : [],
+        mishaps: [],
+        timeCost: 1
+      };
+    },
+    roll(node, rng) {
+      const rideRange = normalizeRange(node?.profile?.yields?.ride, { min: 1, max: 3 });
+      const rideGain = pickInt(rng, rideRange);
+      const mechanicBonus = node?.profile?.services?.mechanic ? 1 : 0;
+      const totalRide = Math.max(1, rideGain + mechanicBonus);
+      const gasCost = node?.profile?.services?.mechanic ? 1 : 2;
+      const parts = [`Ride +${totalRide}`];
+      if (gasCost > 0) {
+        parts.push(`spent ${gasCost} gas`);
+      }
+      return {
+        deltas: { gas: -gasCost, snacks: 0, ride: totalRide, money: 0 },
+        timeCost: 1,
+        message: `${parts.join(', ')}.`
+      };
+    }
+  },
+  scavenge: {
+    id: 'scavenge',
+    title: 'Scavenge',
+    description: 'Pick through the area for loose change and parts.',
+    preview(node) {
+      const moneyRange = normalizeRange(node?.profile?.yields?.money, { min: 1, max: 4 });
+      const hazard = clamp(node?.profile?.hazard ?? 0.35, 0, 1);
+      const rideMax = hazard > 0.6 ? 2 : hazard > 0.4 ? 1 : 0;
+      return {
+        id: 'scavenge',
+        title: this.title,
+        description: this.description,
+        yields: [{ resource: 'money', min: moneyRange.min, max: moneyRange.max }],
+        costs: [],
+        mishaps: rideMax ? [{ resource: 'ride', min: 0, max: rideMax }] : [],
+        timeCost: 1
+      };
+    },
+    roll(node, rng) {
+      const moneyRange = normalizeRange(node?.profile?.yields?.money, { min: 1, max: 4 });
+      const cash = pickInt(rng, moneyRange);
+      const abundance = clamp(node?.profile?.abundance ?? 0.4, 0, 1);
+      let gasFind = 0;
+      if (rng.nextFloat() < abundance * 0.25) {
+        gasFind = 1;
+      }
+      const hazard = clamp(node?.profile?.hazard ?? 0.35, 0, 1);
+      let rideDamage = 0;
+      if (hazard > 0.3 && rng.nextFloat() < hazard * 0.6) {
+        rideDamage = hazard > 0.75 && rng.nextFloat() < 0.4 ? 2 : 1;
+      }
+      const parts = [`Scavenged $${cash}`];
+      if (gasFind > 0) {
+        parts.push('plus 1 gas');
+      }
+      if (rideDamage > 0) {
+        parts.push(`ride -${rideDamage}`);
+      }
+      return {
+        deltas: { gas: gasFind, snacks: 0, ride: -rideDamage, money: cash },
+        timeCost: 1,
+        message: `${parts.join(', ')}.`
+      };
+    }
+  },
+  ferry: {
+    id: 'ferry',
+    title: 'Ferry',
+    description: 'Pay a toll to cross water safely.',
+    preview(node) {
+      const rideRange = normalizeRange(node?.profile?.yields?.ride, { min: 1, max: 3 });
+      const snacksRange = normalizeRange(node?.profile?.yields?.snacks, { min: 0, max: 2 });
+      const cost = computeFerryCost(node?.profile);
+      return {
+        id: 'ferry',
+        title: this.title,
+        description: this.description,
+        yields: [
+          { resource: 'ride', min: rideRange.min, max: rideRange.max },
+          { resource: 'snacks', min: snacksRange.min ? 1 : 0, max: snacksRange.max }
+        ],
+        costs: [{ resource: 'money', amount: cost }],
+        mishaps: [],
+        timeCost: 1
+      };
+    },
+    roll(node, rng) {
+      const rideRange = normalizeRange(node?.profile?.yields?.ride, { min: 1, max: 3 });
+      const rideGain = Math.max(1, Math.round((rideRange.min + rideRange.max) / 2));
+      const snacksRange = normalizeRange(node?.profile?.yields?.snacks, { min: 0, max: 2 });
+      let snackGain = 0;
+      if (snacksRange.max > 0 && rng.nextFloat() < 0.7) {
+        snackGain = pickInt(rng, { min: Math.min(1, snacksRange.max), max: snacksRange.max });
+      }
+      const cost = computeFerryCost(node?.profile);
+      const parts = [`Paid $${cost} for the ferry`, `ride +${rideGain}`];
+      if (snackGain > 0) {
+        parts.push(`restocked ${snackGain} snacks`);
+      }
+      return {
+        deltas: { gas: 0, snacks: snackGain, ride: rideGain, money: -cost },
+        timeCost: 1,
+        message: `${parts.join(', ')}.`
+      };
+    }
+  },
+  shop: {
+    id: 'shop',
+    title: 'Shop',
+    description: 'Visit shops and upgrade stands for supplies.',
+    preview(node) {
+      const gasRange = normalizeRange(node?.profile?.yields?.gas, { min: 1, max: 4 });
+      const snackRange = normalizeRange(node?.profile?.yields?.snacks, { min: 1, max: 4 });
+      const cost = computeShopCost(node?.profile);
+      return {
+        id: 'shop',
+        title: this.title,
+        description: this.description,
+        yields: [
+          { resource: 'gas', min: gasRange.min, max: gasRange.max },
+          { resource: 'snacks', min: snackRange.min, max: snackRange.max }
+        ],
+        costs: [{ resource: 'money', amount: cost }],
+        mishaps: [],
+        timeCost: 1
+      };
+    },
+    roll(node, rng) {
+      const gasRange = normalizeRange(node?.profile?.yields?.gas, { min: 1, max: 4 });
+      const snackRange = normalizeRange(node?.profile?.yields?.snacks, { min: 1, max: 4 });
+      const gasGain = pickInt(rng, gasRange);
+      const snackGain = pickInt(rng, snackRange);
+      const cost = computeShopCost(node?.profile);
+      const parts = [`Bought supplies for $${cost}`, `gas +${gasGain}`, `snacks +${snackGain}`];
+      return {
+        deltas: { gas: gasGain, snacks: snackGain, ride: 0, money: -cost },
+        timeCost: 1,
+        message: `${parts.join(', ')}.`
+      };
+    }
+  }
+};
+
+export function getActionDefinition(actionId) {
+  return ACTION_DEFINITIONS[actionId] || null;
+}
+
+export function computeActionPreview(node, actionId) {
+  const definition = getActionDefinition(actionId);
+  if (!definition || typeof definition.preview !== 'function') {
+    return null;
+  }
+  return definition.preview(node);
+}
+
+export function rollActionOutcome({ actionId, node, seed, usage = 0 }) {
+  const definition = getActionDefinition(actionId);
+  if (!definition || typeof definition.roll !== 'function') {
+    return null;
+  }
+  const rng = createDerivedRNG(seed, node.id, actionId, usage);
+  const result = definition.roll(node, rng);
+  return {
+    id: actionId,
+    title: definition.title,
+    description: definition.description,
+    ...result
+  };
+}
+
+export function listActions() {
+  return Object.keys(ACTION_DEFINITIONS);
+}

--- a/systems/rng.js
+++ b/systems/rng.js
@@ -63,3 +63,26 @@ export class RNG {
 export function createRNG(seed) {
   return new RNG(seed);
 }
+
+export function deriveSeed(baseSeed, ...parts) {
+  let hash = Number.isInteger(baseSeed) ? baseSeed >>> 0 : Math.floor(baseSeed || 0) >>> 0;
+  if (hash === 0) {
+    hash = 0x1a2b3c4d;
+  }
+  parts.forEach((part) => {
+    const str = String(part ?? '');
+    for (let index = 0; index < str.length; index += 1) {
+      const charCode = str.charCodeAt(index);
+      hash ^= (hash << 5) + (hash >>> 2) + charCode;
+      hash >>>= 0;
+    }
+  });
+  if (hash === 0) {
+    hash = 0x1a2b3c4d;
+  }
+  return hash >>> 0;
+}
+
+export function createDerivedRNG(baseSeed, ...parts) {
+  return new RNG(deriveSeed(baseSeed, ...parts));
+}

--- a/systems/state.js
+++ b/systems/state.js
@@ -1,4 +1,8 @@
 import { RNG } from './rng.js';
+import { loadLegacyGraph } from './graph.js';
+import { generateWorldGraph } from './worldgen.js';
+import { computeActionPreview, getActionDefinition, rollActionOutcome } from './nodeActions.js';
+import { maybeTriggerTravelEncounter } from './travelEncounters.js';
 
 function createMemoryStorage() {
   const store = new Map();
@@ -19,27 +23,33 @@ const defaultStorage = typeof window !== 'undefined' && window.localStorage
   ? window.localStorage
   : createMemoryStorage();
 
+const CURRENT_STATE_VERSION = 2;
+const TIME_SEGMENTS = ['Morning', 'Midday', 'Evening', 'Night'];
+
 export const VEHICLES = [
   {
     id: 'minivan',
     name: 'Prairie Minivan',
     description: 'Balanced and comfortable. Plenty of cup holders and a trusty VHS player.',
     stats: { gas: 8, snacks: 6, ride: 7, money: 60 },
-    traits: ['Balanced consumption', 'Family-friendly']
+    traits: ['Balanced consumption', 'Family-friendly'],
+    efficiency: 1
   },
   {
     id: 'pickup',
     name: 'Northern Pickup',
     description: 'Rugged and ready for rough gravel. A little thirsty on fuel.',
     stats: { gas: 7, snacks: 5, ride: 9, money: 40 },
-    traits: ['Heavy-duty suspension', 'Extra gear rack']
+    traits: ['Heavy-duty suspension', 'Extra gear rack'],
+    efficiency: 1.15
   },
   {
     id: 'schoolbus',
     name: 'Retro School Bus',
     description: 'Converted bus with bunks. Slow, but everyone gets elbow room.',
     stats: { gas: 6, snacks: 9, ride: 8, money: 80 },
-    traits: ['Huge snack pantry', 'Neighborhood legend']
+    traits: ['Huge snack pantry', 'Neighborhood legend'],
+    efficiency: 1.25
   }
 ];
 
@@ -105,12 +115,30 @@ function instantiateDefaultParty() {
 
 const LOG_LIMIT = 40;
 
+function computeVehicleEfficiency(vehicle) {
+  if (!vehicle) {
+    return 1;
+  }
+  if (typeof vehicle.efficiency === 'number') {
+    return vehicle.efficiency;
+  }
+  return 1;
+}
+
+function formatTimestamp(state) {
+  const day = state?.day ?? 1;
+  const segmentIndex = state?.timeSegment ?? 0;
+  const label = TIME_SEGMENTS[segmentIndex % TIME_SEGMENTS.length];
+  return label ? `[Day ${day} • ${label}]` : `[Day ${day}]`;
+}
+
 export class GameState {
   constructor(options = {}) {
     this.storageKey = options.storageKey || 'canadian-trail-save';
     this.storage = options.storage || defaultStorage;
     this.state = null;
     this.rng = null;
+    this.worldGraph = null;
   }
 
   async initialize() {
@@ -119,7 +147,10 @@ export class GameState {
       this.state = saved;
       const rngState = saved.rngState ?? saved.seed;
       this.rng = new RNG(saved.seed, rngState);
+      this._migrateState();
+      await this._ensureWorldGraph();
       this._syncRng();
+      this._persist();
     }
   }
 
@@ -127,7 +158,7 @@ export class GameState {
     return Boolean(this.state);
   }
 
-  startNewRun({ seed, vehicleId } = {}) {
+  async startNewRun({ seed, vehicleId } = {}) {
     const vehicle = VEHICLES.find((entry) => entry.id === vehicleId) || VEHICLES[0];
     const resolvedSeed = Number.isInteger(seed) ? seed : Math.floor(Number(seed) || Date.now());
     this.rng = new RNG(resolvedSeed);
@@ -141,28 +172,41 @@ export class GameState {
     const roster = instantiateDefaultParty();
 
     this.state = {
-      version: 1,
+      version: CURRENT_STATE_VERSION,
       seed: resolvedSeed,
       rngState: this.rng.serialize().state,
       day: 1,
+      timeSegment: 0,
       vehicle: {
         id: vehicle.id,
         name: vehicle.name,
         traits: vehicle.traits,
-        description: vehicle.description
+        description: vehicle.description,
+        efficiency: computeVehicleEfficiency(vehicle)
       },
       resources,
       maxResources,
       party: roster,
-      log: ['Packed the cooler, topped up the tank, ready to roll from Halifax!'],
-      location: 'halifax-hub',
-      visited: ['halifax-hub'],
+      log: [],
+      location: null,
+      visited: [],
+      knowledge: {},
+      actionHistory: {},
       flags: {
         gameOver: false
+      },
+      world: {
+        seed: resolvedSeed,
+        version: null,
+        type: 'generated'
       }
     };
 
-    this._persist();
+    await this._ensureWorldGraph({ regenerate: true });
+
+    const startNode = this.worldGraph?.nodes?.get(this.state.location);
+    const startName = startNode?.name || 'Halifax Harbour';
+    this.appendLog(`Packed the cooler, topped up the tank, ready to roll from ${startName}!`);
   }
 
   getSnapshot() {
@@ -179,32 +223,183 @@ export class GameState {
     if (!this.state) {
       return;
     }
-    this.state.log.push(`[Day ${this.state.day}] ${entry}`);
+    const stamped = `${formatTimestamp(this.state)} ${entry}`;
+    this.state.log.push(stamped);
     if (this.state.log.length > LOG_LIMIT) {
       this.state.log.splice(0, this.state.log.length - LOG_LIMIT);
     }
     this._persist();
   }
 
-  travelTo(nodeId, context = {}) {
+  async ensureWorldReady() {
+    await this._ensureWorldGraph();
+    return this.worldGraph;
+  }
+
+  getWorldGraph() {
+    return this.worldGraph;
+  }
+
+  getTravelEstimate(fromId, toId) {
+    if (!this.worldGraph) {
+      return null;
+    }
+    const fromNode = this.worldGraph.nodes.get(fromId);
+    const toNode = this.worldGraph.nodes.get(toId);
+    if (!fromNode || !toNode) {
+      return null;
+    }
+    const connection = fromNode.connections?.find((entry) => entry.id === toId);
+    if (!connection) {
+      return null;
+    }
+    const distance = typeof connection.distance === 'number' ? connection.distance : 1;
+    const roughness = typeof connection.roughness === 'number' ? connection.roughness : connection.rough ? 1.3 : 1;
+    const hazard = Math.max(0, Math.min(1, typeof connection.hazard === 'number' ? connection.hazard : 0.25));
+    const efficiency = this.state?.vehicle?.efficiency ?? 1;
+    const gasCost = Math.max(1, Math.round(distance * efficiency * roughness));
+    const snackCost = 1;
+    const rideMax = hazard > 0.75 ? 3 : hazard > 0.5 ? 2 : hazard > 0.25 ? 1 : 0;
+    return {
+      from: fromNode,
+      to: toNode,
+      connection,
+      distance,
+      roughness,
+      hazard,
+      gasCost,
+      snackCost,
+      timeCost: 1,
+      rideRange: { min: 0, max: rideMax }
+    };
+  }
+
+  getActionOptions(nodeId) {
+    if (!this.worldGraph) {
+      return [];
+    }
+    const node = this.worldGraph.nodes.get(nodeId);
+    if (!node || !Array.isArray(node.actions)) {
+      return [];
+    }
+    return node.actions.map((actionId) => {
+      const definition = getActionDefinition(actionId);
+      const preview = computeActionPreview(node, actionId);
+      const history = this.state?.actionHistory?.[nodeId]?.[actionId] ?? 0;
+      const costs = Array.isArray(preview?.costs) ? preview.costs : [];
+      let available = true;
+      let reason = '';
+      if (history > 0) {
+        available = false;
+        reason = 'Already completed.';
+      }
+      if (available) {
+        const missing = costs.find((cost) => {
+          const amount = typeof cost.amount === 'number' ? cost.amount : cost.min ?? 0;
+          const resourceValue = this.state?.resources?.[cost.resource];
+          return typeof resourceValue === 'number' && resourceValue < amount;
+        });
+        if (missing) {
+          available = false;
+          reason = `Need more ${missing.resource}.`;
+        }
+      }
+      return {
+        id: actionId,
+        definition,
+        preview,
+        available,
+        reason,
+        used: history > 0
+      };
+    });
+  }
+
+  performNodeAction(actionId) {
+    if (!this.state || this.state.flags.gameOver) {
+      return { ok: false, reason: 'Journey complete.' };
+    }
+    if (!this.worldGraph) {
+      return { ok: false, reason: 'Map not ready yet.' };
+    }
+    const nodeId = this.state.location;
+    const node = this.worldGraph.nodes.get(nodeId);
+    if (!node || !node.actions?.includes(actionId)) {
+      return { ok: false, reason: 'Action unavailable here.' };
+    }
+    const history = this.state.actionHistory?.[nodeId]?.[actionId] ?? 0;
+    if (history > 0) {
+      return { ok: false, reason: 'Already completed.' };
+    }
+    const preview = computeActionPreview(node, actionId);
+    const costs = Array.isArray(preview?.costs) ? preview.costs : [];
+    const insufficient = costs.find((cost) => {
+      const amount = typeof cost.amount === 'number' ? cost.amount : cost.min ?? 0;
+      const resourceValue = this.state.resources?.[cost.resource];
+      return typeof resourceValue === 'number' && resourceValue < amount;
+    });
+    if (insufficient) {
+      return { ok: false, reason: `Need ${insufficient.resource} ${insufficient.amount ?? insufficient.min}.` };
+    }
+    const result = rollActionOutcome({ actionId, node, seed: this.state.seed, usage: history });
+    if (!result) {
+      return { ok: false, reason: 'Action not ready yet.' };
+    }
+    const timeCost = Math.max(1, Math.round(result.timeCost || 1));
+    this._advanceTime('action', timeCost);
+    this._applyResourceDeltas(result.deltas || {});
+
+    if (!this.state.actionHistory[nodeId]) {
+      this.state.actionHistory[nodeId] = {};
+    }
+    this.state.actionHistory[nodeId][actionId] = history + 1;
+
+    const message = result.message || `${result.title} complete.`;
+    this.appendLog(`${result.title} at ${node.name}: ${message}`);
+    this._persist();
+
+    return {
+      ok: true,
+      message,
+      deltas: result.deltas || {},
+      timeCost
+    };
+  }
+
+  travelTo(nodeId, _context = {}) {
     if (!this.state || this.state.flags.gameOver) {
       return null;
     }
-
     const previous = this.state.location;
-    this.state.day += 1;
+    if (previous === nodeId) {
+      return null;
+    }
+    const estimate = this.getTravelEstimate(previous, nodeId);
+    if (!estimate) {
+      return null;
+    }
 
-    const gasCost = Math.max(1, Math.round(context.distance || 1));
-    const snackCost = 1;
+    this._advanceTime('travel');
+
+    const gasCost = estimate.gasCost;
+    const snackCost = estimate.snackCost;
 
     this.state.resources.gas = Math.max(0, this.state.resources.gas - gasCost);
     this.state.resources.snacks = Math.max(0, this.state.resources.snacks - snackCost);
 
     let rideDamage = 0;
-    if (context.roughRoad) {
-      rideDamage = this.rng.nextFloat() < 0.6 ? 2 : 1;
-    } else {
-      rideDamage = this.rng.nextFloat() < 0.25 ? 1 : 0;
+    const hazard = estimate.hazard;
+    if (hazard > 0.15) {
+      const hazardRoll = this.rng.nextFloat();
+      if (hazardRoll < hazard) {
+        if (hazard > 0.75) {
+          rideDamage = this.rng.nextFloat() < 0.5 ? 3 : 2;
+        } else if (hazard > 0.5) {
+          rideDamage = this.rng.nextFloat() < 0.6 ? 2 : 1;
+        } else {
+          rideDamage = 1;
+        }
+      }
     }
     this.state.resources.ride = Math.max(0, this.state.resources.ride - rideDamage);
 
@@ -219,11 +414,20 @@ export class GameState {
     if (!this.state.visited.includes(nodeId)) {
       this.state.visited.push(nodeId);
     }
+    this._markKnowledge(nodeId);
 
-    const summary = `Drove from ${context.fromName || previous} to ${context.toName || nodeId}. -${gasCost} gas, -${snackCost} snacks${rideDamage ? `, ride -${rideDamage}` : ''}.`;
+    maybeTriggerTravelEncounter(this, {
+      fromNodeId: previous,
+      toNodeId: nodeId,
+      distance: estimate.distance,
+      roughness: estimate.roughness
+    });
+
+    const fromName = estimate.from?.name || previous;
+    const toName = estimate.to?.name || nodeId;
+    const summary = `Drove from ${fromName} to ${toName}. -${gasCost} gas, -${snackCost} snacks${rideDamage ? `, ride -${rideDamage}` : ''}.`;
     this.appendLog(summary);
     this._syncRng();
-    this._persist();
 
     const depleted = this.resourcesDepleted();
     if (depleted.length > 0) {
@@ -235,7 +439,8 @@ export class GameState {
       snackCost,
       rideDamage,
       hungry: hungryParty,
-      depleted
+      depleted,
+      estimate
     };
   }
 
@@ -255,10 +460,9 @@ export class GameState {
     const { resources = {}, log, flags = {} } = effects;
     Object.entries(resources).forEach(([key, value]) => {
       if (typeof this.state.resources[key] === 'number') {
-        this.state.resources[key] = Math.min(
-          this.state.maxResources[key] ?? Number.POSITIVE_INFINITY,
-          Math.max(0, this.state.resources[key] + value)
-        );
+        const max = this.state.maxResources?.[key];
+        const capped = typeof max === 'number' ? Math.min(max, this.state.resources[key] + value) : this.state.resources[key] + value;
+        this.state.resources[key] = Math.max(0, capped);
       }
     });
     Object.entries(flags).forEach(([flag, value]) => {
@@ -284,6 +488,132 @@ export class GameState {
     this.storage.removeItem(this.storageKey);
     this.state = null;
     this.rng = null;
+    this.worldGraph = null;
+  }
+
+  _markKnowledge(nodeId) {
+    if (!this.state.knowledge) {
+      this.state.knowledge = {};
+    }
+    if (!this.state.knowledge[nodeId]) {
+      this.state.knowledge[nodeId] = { seen: true };
+    } else {
+      this.state.knowledge[nodeId].seen = true;
+    }
+  }
+
+  _applyResourceDeltas(deltas) {
+    if (!this.state || !deltas) {
+      return;
+    }
+    Object.entries(deltas).forEach(([resource, value]) => {
+      if (typeof this.state.resources[resource] !== 'number') {
+        return;
+      }
+      const max = this.state.maxResources?.[resource];
+      const current = this.state.resources[resource];
+      const next = current + value;
+      if (typeof max === 'number') {
+        this.state.resources[resource] = Math.max(0, Math.min(max, next));
+      } else {
+        this.state.resources[resource] = Math.max(0, next);
+      }
+    });
+  }
+
+  _advanceTime(mode, segments = 1) {
+    if (!this.state) {
+      return;
+    }
+    if (mode === 'travel') {
+      this.state.day += 1;
+      this.state.timeSegment = 0;
+      return;
+    }
+    if (mode === 'action') {
+      const steps = Math.max(1, segments | 0);
+      for (let index = 0; index < steps; index += 1) {
+        this.state.timeSegment = (this.state.timeSegment + 1) % TIME_SEGMENTS.length;
+        if (this.state.timeSegment === 0) {
+          this.state.day += 1;
+        }
+      }
+    }
+  }
+
+  async _ensureWorldGraph({ regenerate = false } = {}) {
+    if (!this.state) {
+      return null;
+    }
+    const worldInfo = this.state.world || { version: 1, type: 'legacy', seed: this.state.seed };
+    if (!regenerate && this.worldGraph) {
+      return this.worldGraph;
+    }
+
+    if (worldInfo.type === 'legacy' || worldInfo.version === 1) {
+      const graph = await loadLegacyGraph();
+      this.worldGraph = graph;
+      if (!this.state.location || !graph.nodes.has(this.state.location)) {
+        this.state.location = graph.start;
+      }
+      if (!Array.isArray(this.state.visited) || this.state.visited.length === 0) {
+        this.state.visited = [this.state.location];
+      } else if (!this.state.visited.includes(this.state.location)) {
+        this.state.visited.unshift(this.state.location);
+      }
+      this._markKnowledge(this.state.location);
+      this.state.world = { version: 1, type: 'legacy', seed: this.state.seed };
+      return this.worldGraph;
+    }
+
+    const baseSeed = worldInfo.seed ?? this.state.seed;
+    const world = await generateWorldGraph({ baseSeed });
+    this.worldGraph = world;
+    this.state.world.version = world.version;
+    this.state.world.seed = baseSeed;
+    this.state.world.type = 'generated';
+    if (!this.state.location || !world.nodes.has(this.state.location)) {
+      this.state.location = world.start;
+    }
+    if (!Array.isArray(this.state.visited) || this.state.visited.length === 0) {
+      this.state.visited = [this.state.location];
+    } else if (!this.state.visited.includes(this.state.location)) {
+      this.state.visited.unshift(this.state.location);
+    }
+    this._markKnowledge(this.state.location);
+    return this.worldGraph;
+  }
+
+  _migrateState() {
+    if (!this.state) {
+      return;
+    }
+    if (typeof this.state.version !== 'number' || this.state.version < CURRENT_STATE_VERSION) {
+      this.state.version = CURRENT_STATE_VERSION;
+    }
+    if (typeof this.state.timeSegment !== 'number') {
+      this.state.timeSegment = 0;
+    }
+    if (!Array.isArray(this.state.visited)) {
+      this.state.visited = [];
+    }
+    if (!this.state.knowledge) {
+      this.state.knowledge = {};
+    }
+    if (!this.state.actionHistory) {
+      this.state.actionHistory = {};
+    }
+    if (!this.state.world) {
+      this.state.world = { version: 1, type: 'legacy', seed: this.state.seed };
+    } else if (!this.state.world.type) {
+      this.state.world.type = this.state.world.version && this.state.world.version >= 2 ? 'generated' : 'legacy';
+    }
+    if (!this.state.location && this.state.visited.length > 0) {
+      [this.state.location] = this.state.visited;
+    }
+    if (this.state.location) {
+      this._markKnowledge(this.state.location);
+    }
   }
 
   _syncRng() {

--- a/systems/travelEncounters.js
+++ b/systems/travelEncounters.js
@@ -1,0 +1,4 @@
+export function maybeTriggerTravelEncounter(_game, _context) {
+  // Placeholder for future surreal Canadian travel events.
+  return null;
+}

--- a/systems/worldgen.js
+++ b/systems/worldgen.js
@@ -1,0 +1,486 @@
+import { loadJSON } from './jsonLoader.js';
+import { RNG, deriveSeed } from './rng.js';
+
+const WORLD_DATA_PATH = '../data/world.json';
+
+let cachedConfig = null;
+
+const KIND_LIBRARY = {
+  checkpoint: {
+    actions: ['shop', 'tinker'],
+    baseYields: {
+      gas: [2, 5],
+      snacks: [2, 6],
+      ride: [2, 4],
+      money: [2, 5]
+    },
+    abundanceRange: [0.5, 0.75],
+    prosperityRange: [0.55, 0.8],
+    maintenanceRange: [0.6, 0.9],
+    hazardRange: [0.08, 0.18],
+    roughnessRange: [0.9, 1.05],
+    services: { mechanic: true, shop: true },
+    shopCostRange: [3, 5]
+  },
+  gas: {
+    actions: ['siphon', 'scavenge'],
+    baseYields: {
+      gas: [2, 6],
+      snacks: [0, 2],
+      ride: [0, 2],
+      money: [1, 4]
+    },
+    abundanceRange: [0.45, 0.85],
+    prosperityRange: [0.2, 0.5],
+    maintenanceRange: [0.25, 0.45],
+    hazardRange: [0.15, 0.32],
+    roughnessRange: [0.95, 1.15],
+    services: {}
+  },
+  forest: {
+    actions: ['forage', 'scavenge'],
+    baseYields: {
+      gas: [0, 2],
+      snacks: [2, 6],
+      ride: [1, 3],
+      money: [0, 2]
+    },
+    abundanceRange: [0.5, 0.9],
+    prosperityRange: [0.1, 0.4],
+    maintenanceRange: [0.35, 0.55],
+    hazardRange: [0.18, 0.42],
+    roughnessRange: [1.05, 1.3],
+    services: {}
+  },
+  mechanic: {
+    actions: ['tinker', 'scavenge'],
+    baseYields: {
+      gas: [0, 3],
+      snacks: [0, 3],
+      ride: [2, 6],
+      money: [1, 3]
+    },
+    abundanceRange: [0.3, 0.55],
+    prosperityRange: [0.35, 0.6],
+    maintenanceRange: [0.65, 0.95],
+    hazardRange: [0.12, 0.28],
+    roughnessRange: [0.95, 1.2],
+    services: { mechanic: true },
+    shopCostRange: [3, 5]
+  },
+  town: {
+    actions: ['shop', 'tinker'],
+    baseYields: {
+      gas: [1, 5],
+      snacks: [2, 6],
+      ride: [1, 3],
+      money: [2, 6]
+    },
+    abundanceRange: [0.45, 0.7],
+    prosperityRange: [0.4, 0.8],
+    maintenanceRange: [0.45, 0.7],
+    hazardRange: [0.08, 0.22],
+    roughnessRange: [0.9, 1.1],
+    services: { mechanic: true, shop: true },
+    shopCostRange: [3, 6]
+  },
+  ferry: {
+    actions: ['ferry', 'shop'],
+    baseYields: {
+      gas: [0, 2],
+      snacks: [1, 4],
+      ride: [2, 5],
+      money: [1, 3]
+    },
+    abundanceRange: [0.35, 0.6],
+    prosperityRange: [0.45, 0.75],
+    maintenanceRange: [0.55, 0.8],
+    hazardRange: [0.05, 0.18],
+    roughnessRange: [0.85, 1.05],
+    services: { ferry: true, shop: true },
+    ferryCostRange: [3, 6],
+    shopCostRange: [3, 5]
+  },
+  ghost: {
+    actions: ['scavenge', 'siphon'],
+    baseYields: {
+      gas: [1, 5],
+      snacks: [0, 2],
+      ride: [0, 2],
+      money: [1, 4]
+    },
+    abundanceRange: [0.25, 0.55],
+    prosperityRange: [0.1, 0.35],
+    maintenanceRange: [0.2, 0.45],
+    hazardRange: [0.35, 0.75],
+    roughnessRange: [1.1, 1.45],
+    services: {}
+  },
+  vista: {
+    actions: ['forage', 'scavenge'],
+    baseYields: {
+      gas: [0, 2],
+      snacks: [1, 4],
+      ride: [1, 4],
+      money: [0, 3]
+    },
+    abundanceRange: [0.35, 0.65],
+    prosperityRange: [0.25, 0.55],
+    maintenanceRange: [0.45, 0.75],
+    hazardRange: [0.1, 0.32],
+    roughnessRange: [0.9, 1.2],
+    services: { shop: false }
+  }
+};
+
+const NAME_PARTS = {
+  gas: {
+    prefixes: ['Prairie', 'Twin Pines', 'Maple Leaf', 'Aurora', 'Polar', 'Sundog', 'Blueberry', 'Totem'],
+    suffixes: ['Fuel Stop', 'Gas Co-op', 'Service', 'Pump Row', 'Fuel Depot', 'Roadhouse']
+  },
+  forest: {
+    prefixes: ['Whispering', 'Moosejaw', 'Snowberry', 'Birch Ridge', 'Skyline', 'Trout Lake', 'Cedar Grove', 'Windrift'],
+    suffixes: ['Backcountry', 'Provincial Park', 'Trailhead', 'Woodlot', 'Bog', 'Reserve']
+  },
+  mechanic: {
+    prefixes: ['Rusty', 'Frontier', 'High Gear', 'Prairie', 'Snowcap', 'True North', 'Frostbite'],
+    suffixes: ['Garage', 'Repair Yard', 'Workshop', 'Tune-Up', 'Motor Shed', 'Pit Stop']
+  },
+  town: {
+    prefixes: ['Friendly', 'Summit', 'Maple Ridge', 'Twin Lakes', 'Aurora', 'Canyon', 'Prairie Light'],
+    suffixes: ['Trading Post', 'Township', 'Market', 'Crossing', 'Village', 'Harbour']
+  },
+  ferry: {
+    prefixes: ['Silver', 'Lakeline', 'Twin Current', 'North Star', 'Baylight', 'Cedar', 'Salish'],
+    suffixes: ['Ferry', 'Crossing', 'Passage', 'Pontoon', 'Causeway', 'Jetty']
+  },
+  ghost: {
+    prefixes: ['Abandoned', 'Fog Hollow', 'Stormcell', 'Rusted', 'Coyote', 'Shadow', 'Grim Cedar'],
+    suffixes: ['Service Road', 'Ghost Town', 'Rest Stop', 'Storm Cell', 'Empty Lot', 'Drift']
+  },
+  vista: {
+    prefixes: ['Sunset', 'Aurora', 'Eagle Eye', 'Skyline', 'Prairie Light', 'Glacial', 'Rainshadow'],
+    suffixes: ['Vista', 'Lookout', 'Rest', 'Scenic Pullout', 'Overlook', 'Summit']
+  }
+};
+
+const SEGMENT_KIND_POOL = [
+  'forest',
+  'gas',
+  'town',
+  'mechanic',
+  'forest',
+  'vista',
+  'ghost',
+  'gas',
+  'ferry',
+  'forest',
+  'town'
+];
+
+const BRANCH_KIND_POOL = ['ghost', 'vista', 'gas', 'forest', 'ghost', 'ferry'];
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function ensureConfig(config) {
+  if (!config || !Array.isArray(config.checkpoints) || config.checkpoints.length === 0) {
+    throw new Error('World configuration missing checkpoints');
+  }
+  return config;
+}
+
+function scaleRange([minBase = 0, maxBase = 0], factor) {
+  const min = Math.max(0, Math.round(lerp(minBase, (minBase + maxBase) / 2, factor * 0.6)));
+  const span = Math.max(0, maxBase - minBase);
+  const projectedMax = minBase + span * (0.4 + factor * 0.6);
+  const max = Math.max(min, Math.round(projectedMax));
+  return { min, max };
+}
+
+function buildProfile(kindKey, rng) {
+  const template = KIND_LIBRARY[kindKey] || KIND_LIBRARY.forest;
+  const abundance = rng.nextRange(template.abundanceRange[0], template.abundanceRange[1]);
+  const prosperity = rng.nextRange(template.prosperityRange[0], template.prosperityRange[1]);
+  const maintenance = rng.nextRange(template.maintenanceRange[0], template.maintenanceRange[1]);
+  const hazard = rng.nextRange(template.hazardRange[0], template.hazardRange[1]);
+  const roughness = rng.nextRange(template.roughnessRange[0], template.roughnessRange[1]);
+  const yields = {
+    gas: scaleRange(template.baseYields.gas, abundance),
+    snacks: scaleRange(template.baseYields.snacks, abundance),
+    ride: scaleRange(template.baseYields.ride, maintenance),
+    money: scaleRange(template.baseYields.money, prosperity)
+  };
+  const services = { ...(template.services || {}) };
+  if (services.shop) {
+    const [minCost = 3, maxCost = 6] = template.shopCostRange || [3, 6];
+    services.shopCost = lerp(minCost, maxCost, prosperity);
+  }
+  if (services.ferry) {
+    const [minCost = 3, maxCost = 6] = template.ferryCostRange || [3, 6];
+    services.ferryCost = lerp(minCost, maxCost, prosperity);
+  }
+  return {
+    abundance,
+    prosperity,
+    maintenance,
+    hazard,
+    roughness,
+    yields,
+    services
+  };
+}
+
+function createShortName(name) {
+  if (!name) {
+    return '';
+  }
+  if (name.length <= 16) {
+    return name;
+  }
+  const parts = name.split(' ');
+  if (parts.length === 1) {
+    return parts[0].slice(0, 14);
+  }
+  const candidate = `${parts[0]} ${parts[1]}`;
+  if (candidate.length <= 16) {
+    return candidate;
+  }
+  return `${parts[0]} ${parts[parts.length - 1].slice(0, 6)}`.trim();
+}
+
+function buildName(kind, rng) {
+  const parts = NAME_PARTS[kind];
+  if (!parts) {
+    return null;
+  }
+  const prefix = parts.prefixes[rng.nextInt(0, parts.prefixes.length - 1)];
+  const suffix = parts.suffixes[rng.nextInt(0, parts.suffixes.length - 1)];
+  return `${prefix} ${suffix}`;
+}
+
+function createNode({ id, kind, coords, region, rng }) {
+  const template = KIND_LIBRARY[kind] || KIND_LIBRARY.forest;
+  const profile = buildProfile(kind, rng);
+  const name = buildName(kind, rng) || `${kind} waypoint`;
+  return {
+    id,
+    kind,
+    name,
+    shortName: createShortName(name),
+    coords: {
+      x: Number(coords.x.toFixed(2)),
+      y: Number(coords.y.toFixed(2))
+    },
+    region,
+    actions: [...new Set(template.actions || [])],
+    profile,
+    connections: []
+  };
+}
+
+function addConnection(node, target, data) {
+  if (!node.connections) {
+    node.connections = [];
+  }
+  const exists = node.connections.some((entry) => entry.id === target.id);
+  if (exists) {
+    return;
+  }
+  node.connections.push({
+    id: target.id,
+    distance: Number(data.distance.toFixed(2)),
+    roughness: Number(data.roughness.toFixed(3)),
+    rough: data.rough,
+    hazard: Number(data.hazard.toFixed(3))
+  });
+}
+
+function averageHazard(nodeA, nodeB) {
+  const a = nodeA.profile?.hazard ?? 0.2;
+  const b = nodeB.profile?.hazard ?? 0.2;
+  return (a + b) / 2;
+}
+
+function averageRoughness(nodeA, nodeB) {
+  const a = nodeA.profile?.roughness ?? 1;
+  const b = nodeB.profile?.roughness ?? 1;
+  return (a + b) / 2;
+}
+
+function computeDistance(nodeA, nodeB) {
+  const dx = nodeB.coords.x - nodeA.coords.x;
+  const dy = nodeB.coords.y - nodeA.coords.y;
+  const distance = Math.hypot(dx, dy);
+  const scaled = distance / 12;
+  return Math.max(0.6, scaled);
+}
+
+function connectBidirectional(nodeA, nodeB) {
+  const distance = computeDistance(nodeA, nodeB);
+  const roughness = averageRoughness(nodeA, nodeB);
+  const hazard = averageHazard(nodeA, nodeB);
+  const rough = roughness > 1.15;
+  addConnection(nodeA, nodeB, { distance, roughness, hazard, rough });
+  addConnection(nodeB, nodeA, { distance, roughness, hazard, rough });
+}
+
+function pickKindForSegment(rng) {
+  return SEGMENT_KIND_POOL[rng.nextInt(0, SEGMENT_KIND_POOL.length - 1)];
+}
+
+function pickKindForBranch(rng) {
+  return BRANCH_KIND_POOL[rng.nextInt(0, BRANCH_KIND_POOL.length - 1)];
+}
+
+function buildEdges(nodes) {
+  const edges = [];
+  nodes.forEach((node) => {
+    (node.connections || []).forEach((connection) => {
+      edges.push({ from: node.id, to: connection.id });
+    });
+  });
+  return edges;
+}
+
+export async function loadWorldConfig() {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+  const data = await loadJSON(WORLD_DATA_PATH);
+  cachedConfig = ensureConfig(data);
+  return cachedConfig;
+}
+
+export async function generateWorldGraph({ baseSeed }) {
+  const config = await loadWorldConfig();
+  const worldVersion = Number(config.worldVersion) || 1;
+  const checkpoints = config.checkpoints.map((entry) => ({ ...entry }));
+  const rng = new RNG(deriveSeed(baseSeed, 'world', worldVersion));
+  const nodes = new Map();
+
+  checkpoints.forEach((checkpoint, index) => {
+    const base = KIND_LIBRARY.checkpoint;
+    const profileRng = new RNG(deriveSeed(baseSeed, 'checkpoint', checkpoint.id, index));
+    const profile = buildProfile('checkpoint', profileRng);
+    const node = {
+      id: checkpoint.id,
+      kind: 'checkpoint',
+      name: checkpoint.name,
+      shortName: checkpoint.shortName || createShortName(checkpoint.name),
+      coords: {
+        x: Number((checkpoint.coords?.x ?? 0).toFixed(2)),
+        y: Number((checkpoint.coords?.y ?? 0).toFixed(2))
+      },
+      region: checkpoint.region || 'Canada',
+      actions: checkpoint.actions ? [...new Set(checkpoint.actions)] : [...base.actions],
+      profile: {
+        ...profile,
+        services: {
+          ...profile.services,
+          ...(checkpoint.services || {})
+        }
+      },
+      connections: []
+    };
+    nodes.set(node.id, node);
+  });
+
+  let globalCounter = 0;
+
+  for (let segmentIndex = 0; segmentIndex < checkpoints.length - 1; segmentIndex += 1) {
+    const startCheckpoint = checkpoints[segmentIndex];
+    const endCheckpoint = checkpoints[segmentIndex + 1];
+    const startNode = nodes.get(startCheckpoint.id);
+    const endNode = nodes.get(endCheckpoint.id);
+    if (!startNode || !endNode) {
+      continue;
+    }
+
+    const mainCount = rng.nextInt(2, 5);
+    const mainNodes = [];
+    const dirX = endNode.coords.x - startNode.coords.x;
+    const dirY = endNode.coords.y - startNode.coords.y;
+    const length = Math.hypot(dirX, dirY) || 1;
+    const norm = { x: dirX / length, y: dirY / length };
+    const perp = { x: -norm.y, y: norm.x };
+
+    for (let index = 1; index <= mainCount; index += 1) {
+      const t = index / (mainCount + 1);
+      const baseX = lerp(startNode.coords.x, endNode.coords.x, t);
+      const baseY = lerp(startNode.coords.y, endNode.coords.y, t);
+      const lateralScale = length * 0.35 + 3;
+      const lateralOffset = (rng.nextFloat() - 0.5) * lateralScale;
+      const forwardOffset = (rng.nextFloat() - 0.5) * 3;
+      let x = baseX + perp.x * lateralOffset + norm.x * forwardOffset;
+      let y = baseY + perp.y * lateralOffset + norm.y * forwardOffset;
+      const minX = Math.min(startNode.coords.x, endNode.coords.x) - 4;
+      const maxX = Math.max(startNode.coords.x, endNode.coords.x) + 4;
+      x = clamp(x, minX, maxX);
+      y = clamp(y, 8, 92);
+      const kind = pickKindForSegment(rng);
+      const region = t < 0.5 ? startNode.region : endNode.region;
+      const nodeId = `${startNode.id}-${endNode.id}-mid-${segmentIndex}-${index}-${globalCounter++}`;
+      const node = createNode({ id: nodeId, kind, coords: { x, y }, region, rng });
+      nodes.set(node.id, node);
+      mainNodes.push(node);
+    }
+
+    const pathNodes = [startNode, ...mainNodes, endNode];
+    for (let index = 0; index < pathNodes.length - 1; index += 1) {
+      connectBidirectional(pathNodes[index], pathNodes[index + 1]);
+    }
+
+    if (pathNodes.length > 2) {
+      const maxBranches = Math.min(2, pathNodes.length - 1);
+      const branchCount = rng.nextInt(1, Math.max(1, maxBranches));
+      for (let branchIndex = 0; branchIndex < branchCount; branchIndex += 1) {
+        const baseIndex = rng.nextInt(1, pathNodes.length - 2);
+        const reconnectIndex = Math.min(pathNodes.length - 1, baseIndex + rng.nextInt(1, 2));
+        if (reconnectIndex === baseIndex) {
+          continue;
+        }
+        const anchor = pathNodes[baseIndex];
+        const reconnect = pathNodes[reconnectIndex];
+        const branchLength = rng.nextInt(1, 2);
+        let previous = anchor;
+        for (let step = 1; step <= branchLength; step += 1) {
+          const t = step / (branchLength + 1);
+          const midX = lerp(anchor.coords.x, reconnect.coords.x, t);
+          const midY = lerp(anchor.coords.y, reconnect.coords.y, t);
+          const lateralDirection = rng.nextFloat() < 0.5 ? -1 : 1;
+          const offsetMagnitude = (rng.nextFloat() * 0.6 + 0.4) * length * 0.6;
+          let x = midX + perp.x * offsetMagnitude * lateralDirection;
+          let y = midY + perp.y * offsetMagnitude * lateralDirection;
+          const minBranchX = Math.min(startNode.coords.x, endNode.coords.x) - 6;
+          const maxBranchX = Math.max(startNode.coords.x, endNode.coords.x) + 6;
+          x = clamp(x, minBranchX, maxBranchX);
+          y = clamp(y, 6, 94);
+          const kind = pickKindForBranch(rng);
+          const nodeId = `${anchor.id}-spur-${segmentIndex}-${branchIndex}-${step}-${globalCounter++}`;
+          const node = createNode({ id: nodeId, kind, coords: { x, y }, region: anchor.region, rng });
+          nodes.set(node.id, node);
+          connectBidirectional(previous, node);
+          previous = node;
+        }
+        connectBidirectional(previous, reconnect);
+      }
+    }
+  }
+
+  const edges = buildEdges(nodes);
+
+  return {
+    version: worldVersion,
+    seed: baseSeed,
+    start: checkpoints[0].id,
+    nodes,
+    edges,
+    checkpoints: checkpoints.map((entry) => entry.id)
+  };
+}

--- a/tests/run.js
+++ b/tests/run.js
@@ -33,7 +33,7 @@ async function testSaveLoadRoundTrip() {
   })();
 
   const state = new GameState({ storage, storageKey: 'test-save' });
-  state.startNewRun({ seed: 999, vehicleId: 'minivan' });
+  await state.startNewRun({ seed: 999, vehicleId: 'minivan' });
   const original = state.getSnapshot();
 
   const loaded = new GameState({ storage, storageKey: 'test-save' });

--- a/ui/SetupScreen.js
+++ b/ui/SetupScreen.js
@@ -137,12 +137,12 @@ export default class SetupScreen {
     submit.textContent = 'Hit the road';
     form.append(submit);
 
-    form.addEventListener('submit', (event) => {
+    form.addEventListener('submit', async (event) => {
       event.preventDefault();
       const formData = new FormData(form);
       const vehicleId = formData.get('vehicle');
       const seedValue = Number(formData.get('seed'));
-      this.gameState.startNewRun({ seed: seedValue, vehicleId });
+      await this.gameState.startNewRun({ seed: seedValue, vehicleId });
       this.screenManager.navigate('map');
     });
 


### PR DESCRIPTION
## Summary
- implement seeded world generation with checkpoints, branches, and node profiles
- expose deterministic node actions and travel previews with MapScreen UI updates
- maintain save compatibility, add travel hook, and update tests/utilities

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d06dba788320a417e8c149c479db