### PR TITLE
Improve mobile map layout and navigation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -447,6 +447,28 @@ legend {
   inset: 0;
 }
 
+.map-mobile-controls,
+.map-mobile-close,
+.map-mobile-tabs {
+  display: none;
+}
+
+.map-mobile-button {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+}
+
+.map-location-body {
+  display: grid;
+  gap: clamp(0.85rem, 2vw, 1.5rem);
+}
+
+.map-resources-mobile {
+  display: none;
+}
 
 .map-preview {
   position: absolute;
@@ -816,27 +838,194 @@ legend {
 }
 
 @media (max-width: 720px) {
+  body.map-mode {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
+  body.map-mode main#app {
+    height: auto;
+    min-height: 100vh;
+  }
+
   .map-screen {
     padding: clamp(1rem, 5vw, 2rem);
+    padding-bottom: clamp(6rem, 16vw, 8rem);
+    grid-template-rows: auto 1fr;
+    align-content: start;
   }
 
   .map-topbar {
     flex-direction: column;
+    padding: clamp(1rem, 4vw, 1.75rem);
+  }
+
+  .map-heading p {
+    max-width: 100%;
   }
 
   .map-resources {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    width: 100%;
+    display: none;
+  }
+
+  .map-layout {
+    display: block;
+  }
+
+  .map-stage {
+    min-height: clamp(340px, 62vh, 540px);
+  }
+
+  .map-preview {
+    bottom: calc(env(safe-area-inset-bottom, 0) + clamp(5rem, 14vw, 6rem));
+    width: min(320px, 92%);
+  }
+
+  .map-mobile-controls {
+    display: flex;
+    position: absolute;
+    bottom: calc(env(safe-area-inset-bottom, 0) + clamp(1.25rem, 4vw, 2.5rem));
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(640px, calc(100% - 2.5rem));
+    gap: 0.75rem;
+    z-index: 30;
+  }
+
+  .map-mobile-button {
+    flex: 1;
+    padding: 0.65rem 1rem;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(144, 195, 255, 0.4);
+    background: rgba(8, 36, 66, 0.85);
+    color: rgba(236, 244, 255, 0.9);
+    font-size: 0.74rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-weight: 600;
+    box-shadow: 0 1.45rem 3rem rgba(6, 24, 48, 0.45);
+    cursor: pointer;
+  }
+
+  .map-mobile-button[data-active="true"] {
+    background: linear-gradient(180deg, rgba(84, 163, 255, 0.92), rgba(33, 113, 210, 0.92));
+    border-color: rgba(208, 233, 255, 0.85);
+    color: #0b2751;
+    box-shadow: 0 1.5rem 3.2rem rgba(32, 78, 138, 0.48);
+  }
+
+  .map-sidebar {
+    position: fixed;
+    left: 50%;
+    bottom: calc(env(safe-area-inset-bottom, 0) + clamp(1rem, 4vw, 2rem));
+    transform: translate(-50%, calc(100% + 2rem));
+    width: min(640px, calc(100% - 2.5rem));
+    max-height: calc(100vh - clamp(6rem, 18vw, 9rem));
+    overflow-y: auto;
+    padding-bottom: clamp(1.5rem, 4vw, 2.5rem);
+    pointer-events: none;
+    opacity: 0;
+    transition: transform var(--transition), opacity var(--transition);
+    z-index: 40;
+  }
+
+  .map-sidebar[data-open="true"] {
+    transform: translate(-50%, 0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .map-mobile-close,
+  .map-mobile-tabs {
+    display: block;
+  }
+
+  .map-mobile-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: flex-end;
+    padding: 0.45rem 0.85rem;
+    margin: -0.25rem 0 0.75rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(144, 195, 255, 0.4);
+    background: rgba(8, 36, 66, 0.8);
+    color: rgba(236, 244, 255, 0.85);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    box-shadow: none;
+    cursor: pointer;
+  }
+
+  .map-mobile-tabs {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+    padding: 0.5rem;
+    border-radius: var(--radius-md);
+    background: rgba(6, 28, 54, 0.78);
+    border: 1px solid rgba(144, 195, 255, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    margin-bottom: clamp(1rem, 3vw, 1.5rem);
+  }
+
+  .map-mobile-tab {
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 0.45rem 0.75rem;
+    background: transparent;
+    color: rgba(220, 234, 255, 0.72);
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    font-weight: 600;
+    cursor: pointer;
+  }
+
+  .map-mobile-tab[aria-selected="true"] {
+    background: rgba(84, 163, 255, 0.16);
+    color: rgba(240, 248, 255, 0.96);
+    box-shadow: inset 0 0 0 1px rgba(184, 224, 255, 0.35);
+  }
+
+  .map-mobile-button:focus-visible,
+  .map-mobile-close:focus-visible,
+  .map-mobile-tab:focus-visible {
+    outline: 2px solid rgba(208, 233, 255, 0.85);
+    outline-offset: 2px;
+  }
+
+  .map-sidebar [data-panel][data-active="false"] {
+    display: none;
+  }
+
+  .map-resources-mobile {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .map-log-list {
+    max-height: none;
   }
 }
 
 @media (max-width: 520px) {
-  .map-resources {
+  .map-resources-mobile {
     grid-template-columns: 1fr;
   }
 
   .map-stage {
-    min-height: clamp(260px, 62vh, 420px);
+    min-height: clamp(300px, 60vh, 480px);
+  }
+
+  .map-mobile-controls {
+    width: calc(100% - 1.5rem);
+  }
+
+  .map-sidebar {
+    width: calc(100% - 1.5rem);
   }
 }
 
@@ -844,7 +1033,9 @@ legend {
   .map-stage {
     min-height: clamp(240px, 60vh, 420px);
   }
+}
 
+@media (max-height: 700px) and (min-width: 721px) {
   .map-log-list {
     max-height: clamp(9rem, 28vh, 12rem);
   }


### PR DESCRIPTION
## Summary
- add a mobile-first sidebar drawer with tab navigation and controls to access status and logs on small screens
- duplicate the resource board into a mobile panel and update map rendering logic to support the new layout
- refresh responsive styles to surface the map canvas on phones and reposition controls safely on smaller viewports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9dc3a0f38832099e4b38b8d989b59