### PR TITLE
Add deterministic encounters and Canadian event pack

### DIFF
--- a/data/events.json
+++ b/data/events.json
@@ -1,50 +1,453 @@
 {
   "events": [
     {
-      "id": "moose-crossing",
-      "title": "Moose on the Loose",
-      "when": ["travel"],
-      "weight": 2,
-      "requires": { "minDay": 1 },
+      "id": "ogopogo-wake",
+      "title": "Ogopogo’s Wake",
+      "hook": "arrival",
+      "rarity": "rare",
+      "cooldown": 6,
+      "summary": "Ogopogo's wake hummed across the lakefront.",
+      "requires": { "regions": ["British Columbia"] },
       "stages": [
         {
-          "text": "A towering moose meanders into the middle of the Trans-Canada, sizing up your headlights.",
+          "id": "shore",
+          "text": "Kelowna Lake shivers as Ogopogo's wake hums along the rocks.",
           "choices": [
             {
-              "id": "wait",
-              "label": "Idle patiently",
-              "outcome": "You idle in neutral and wait for nature to decide.",
-              "effects": {
-                "resources": { "gas": -1 },
-                "log": "You burn a sip of gas idling behind the moose." },
-              "roll": {
-                "chance": 0.7,
-                "success": {
-                  "outcome": "The moose takes the hint and lumbers off the shoulder.",
-                  "effects": { "log": "The moose wanders away with a frosty snort." }
+              "id": "offer",
+              "label": "Leave smoked salmon",
+              "outcome": "You scatter smoked salmon along the slick stones.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "ogopogo-calm-waters",
+                  "kind": "hazard",
+                  "amount": -0.2,
+                  "duration": 2,
+                  "label": "Calm waters soften upcoming hazards.",
+                  "message": "Calm waters rolled ahead for the next legs."
                 },
-                "failure": {
-                  "outcome": "The moose stares you down and taps the bumper.",
-                  "effects": { "resources": { "ride": -1 }, "log": "Fresh dent! The moose wins this round." }
-                }
-              }
+                { "type": "log", "message": "Left smoked salmon for Ogopogo and the lake fell quiet." }
+              ],
+              "nextStage": "afterglow"
             },
             {
-              "id": "honk",
-              "label": "Lay on the horn",
-              "outcome": "You tap the horn and hope for the best.",
-              "effects": {
-                "resources": { "snacks": -1 },
-                "log": "Everyone stress-eats maple fudge during the standoff." },
+              "id": "search",
+              "label": "Search the shore",
+              "outcome": "You follow the glow, sketching the wake's paths.",
+              "effects": [
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "hazardHints": true,
+                  "message": "Ogopogo traced gentle coves around the lake."
+                },
+                { "type": "log", "message": "Mapped Ogopogo's calm coves around the lake." }
+              ],
+              "nextStage": "afterglow"
+            },
+            {
+              "id": "drift",
+              "label": "Let the song pull you",
+              "outcome": "You ease off the pedals and let the wake tow the van.",
+              "effects": [
+                {
+                  "type": "teleport",
+                  "origin": "destination",
+                  "mode": "forward",
+                  "dayShift": 1,
+                  "message": "Ogopogo towed you ahead overnight."
+                },
+                { "type": "log", "message": "Ogopogo's wake ferried the van forward overnight." }
+              ],
+              "nextStage": "afterglow"
+            }
+          ]
+        },
+        {
+          "id": "afterglow",
+          "text": "Mist lingers as the wake circles back, inviting a parting gesture.",
+          "choices": [
+            {
+              "id": "cup",
+              "label": "Cup the lake water",
+              "outcome": "You share the chill with the crew.",
+              "effects": [
+                { "type": "resources", "changes": { "ride": 1, "snacks": 1 } },
+                { "type": "log", "message": "Ogopogo's gift steadied the crew for the next push." }
+              ]
+            },
+            {
+              "id": "chart",
+              "label": "Chart the ripples",
+              "outcome": "You mark the ripples into a neat pencil map.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "ogopogo-preview",
+                  "kind": "preview-tight",
+                  "duration": 1,
+                  "label": "Lake sense sharpened the next preview.",
+                  "message": "Lake sense sharpened the next preview."
+                },
+                { "type": "log", "message": "Ogopogo's ripples sharpened the family's map sense." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "wendigo-radio",
+      "title": "Wendigo Radio",
+      "hook": "arrival",
+      "rarity": "uncommon",
+      "cooldown": 4,
+      "summary": "A wendigo broadcast whispered through the static.",
+      "requires": { "regions": ["Ontario", "Quebec", "Manitoba"] },
+      "stages": [
+        {
+          "id": "signal",
+          "text": "A rusted cabin radio hums on the dash with a hungry wendigo voice.",
+          "choices": [
+            {
+              "id": "tune",
+              "label": "Tune carefully",
+              "outcome": "You feather the dial until the howl steadies.",
+              "effects": [
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "hazardHints": true,
+                  "message": "The signal flagged calmer side roads."
+                },
+                { "type": "log", "message": "Tuned the wendigo radio and logged the safer spurs." }
+              ],
+              "nextStage": "marker"
+            },
+            {
+              "id": "overdrive",
+              "label": "Overdrive the dial",
+              "outcome": "You crank the dial past sane limits.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "wendigo-gas",
+                  "kind": "travel-gas",
+                  "amount": -1,
+                  "duration": 2,
+                  "label": "Radio deal shaved a liter off each jump.",
+                  "message": "The broadcast bartered a little gas off each jump."
+                },
+                { "type": "log", "message": "Overdrove the wendigo radio and scored a gas discount." }
+              ],
+              "nextStage": "marker"
+            },
+            {
+              "id": "ignore",
+              "label": "Ignore it",
+              "outcome": "You close the glove box on the hiss.",
+              "effects": [
+                { "type": "log", "message": "Ignored the wendigo broadcast and kept the cabin quiet." }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "marker",
+          "text": "The final burst scratches coordinates across the windshield frost.",
+          "choices": [
+            {
+              "id": "pin",
+              "label": "Pin the signal",
+              "outcome": "You jot the numbers onto the paper atlas.",
+              "effects": [
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "maxHazard": 0.35,
+                  "hazardHints": true,
+                  "message": "The note revealed a gentle side route."
+                },
+                { "type": "log", "message": "Pinned the wendigo marker onto the atlas for a softer detour." }
+              ]
+            },
+            {
+              "id": "fade",
+              "label": "Let it fade",
+              "outcome": "You let the phantom signal slip away.",
+              "effects": [
+                { "type": "log", "message": "Let the wendigo broadcast fade back into the static." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "hotel-beneath-snow",
+      "title": "Hotel Beneath the Snow",
+      "hook": "arrival",
+      "rarity": "rare",
+      "cooldown": 7,
+      "summary": "A buried hotel opened its glowing foyer.",
+      "requires": { "regions": ["Manitoba", "Saskatchewan", "Alberta"] },
+      "stages": [
+        {
+          "id": "lobby",
+          "text": "A hotel sunk beneath snowdrifts swings open with warm light.",
+          "choices": [
+            {
+              "id": "rest",
+              "label": "Take the beds",
+              "outcome": "Everyone collapses into quilted bunks.",
+              "effects": [
+                { "type": "resources", "changes": { "ride": 2, "snacks": 1 } },
+                { "type": "log", "message": "Rested under snowbank quilts and patched up the ride." }
+              ],
+              "nextStage": "ledger"
+            },
+            {
+              "id": "boiler",
+              "label": "Check the boiler",
+              "outcome": "You coax the roaring boiler back into rhythm.",
+              "effects": [
+                { "type": "resources", "changes": { "ride": 2 } },
+                { "type": "log", "message": "Tuned the buried boiler and tightened the chassis." }
+              ],
+              "nextStage": "ledger"
+            },
+            {
+              "id": "hall",
+              "label": "Wander the hall",
+              "outcome": "You follow endless hallways of framed voyageurs.",
+              "effects": [
+                { "type": "log", "message": "Wandered the ghostly halls beneath the snow." }
+              ],
               "roll": {
-                "chance": 0.45,
+                "chance": 0.5,
                 "success": {
-                  "outcome": "The honk startles the moose back into the bush.",
-                  "effects": { "log": "Success! The moose sprints into the spruce." }
+                  "outcome": "A freight elevator drops you near the next town.",
+                  "effects": [
+                    {
+                      "type": "teleport",
+                      "origin": "destination",
+                      "mode": "forward",
+                      "message": "The hotel elevator lifted you ahead underground."
+                    },
+                    { "type": "log", "message": "A hidden elevator jumped the van ahead under the drifts." }
+                  ]
                 },
                 "failure": {
-                  "outcome": "The horn enrages the moose.",
-                  "effects": { "resources": { "ride": -2 }, "log": "The moose wallops the hood before sauntering off." }
+                  "outcome": "You loop back to the lobby before dawn.",
+                  "effects": [
+                    { "type": "log", "message": "Lost in the snowbound halls before finding the lobby again." }
+                  ]
+                }
+              },
+              "nextStage": "ledger"
+            }
+          ]
+        },
+        {
+          "id": "ledger",
+          "text": "A frozen clerk slides the guest ledger across the counter.",
+          "choices": [
+            {
+              "id": "sign",
+              "label": "Sign the ledger",
+              "outcome": "You sign with mittened hands.",
+              "effects": [
+                { "type": "resources", "changes": { "money": 10 } },
+                { "type": "log", "message": "Signed the buried ledger and pocketed a refund." }
+              ]
+            },
+            {
+              "id": "pay",
+              "label": "Slip the clerk cash",
+              "outcome": "You slide a few crisp bills across the desk.",
+              "effects": [
+                { "type": "resources", "changes": { "money": -8 } },
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "hazardHints": true,
+                  "maxHazard": 0.4,
+                  "message": "The clerk highlighted the safest exits."
+                },
+                { "type": "log", "message": "Paid the snowbound clerk for directions to safer routes." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "voyageurs-ghost-canoe",
+      "title": "Voyageurs’ Ghost Canoe",
+      "hook": "travel",
+      "rarity": "uncommon",
+      "cooldown": 3,
+      "summary": "A glowing canoe paced the headlights.",
+      "requires": { "regions": ["Ontario", "Manitoba"] },
+      "stages": [
+        {
+          "id": "paddle",
+          "text": "A ghostly canoe glides alongside, paddlers chanting in French.",
+          "choices": [
+            {
+              "id": "pay",
+              "label": "Pay the toll",
+              "outcome": "You toss maple sugar toward the bow.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "voyageur-ward",
+                  "kind": "skip-hazard",
+                  "tick": "manual",
+                  "duration": 1,
+                  "label": "Voyageurs will block the next hazard.",
+                  "message": "The paddlers promised to block the next hazard." },
+                { "type": "log", "message": "Paid the voyageur spirits to block the next hazard." }
+              ],
+              "nextStage": "chant"
+            },
+            {
+              "id": "pace",
+              "label": "Match their pace",
+              "outcome": "You paddle the wheel in time with their strokes.",
+              "effects": [
+                { "type": "resources", "changes": { "snacks": 1 } },
+                { "type": "log", "message": "Kept pace with the voyageur canoe and boosted morale." }
+              ],
+              "nextStage": "chant"
+            },
+            {
+              "id": "peer",
+              "label": "Peer into the canoe",
+              "outcome": "You lean over to study the shimmering hull.",
+              "effects": [
+                { "type": "dayShift", "days": 1, "message": "You slept a year in a blink." },
+                { "type": "log", "message": "Peered into the ghost canoe and lost a day to dreamless sleep." }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "chant",
+          "text": "The paddlers beckon you to join their chant.",
+          "choices": [
+            {
+              "id": "lead",
+              "label": "Lead the refrain",
+              "outcome": "You echo their haunting refrain.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "voyageur-echo",
+                  "kind": "hazard",
+                  "amount": -0.15,
+                  "duration": 1,
+                  "label": "Voyageur chant softened upcoming hazards.",
+                  "message": "The chant softened the next hazard."
+                },
+                { "type": "log", "message": "Led the voyageurs' chant and eased the next hazard." }
+              ]
+            },
+            {
+              "id": "listen",
+              "label": "Listen for the route",
+              "outcome": "You let their harmonies map the bends ahead.",
+              "effects": [
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "hazardHints": true,
+                  "message": "The chant revealed which bends stay calm."
+                },
+                { "type": "log", "message": "Listened to the voyageurs and marked the safest bends ahead." }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "aurora-tollkeeper",
+      "title": "Aurora Tollkeeper",
+      "hook": "travel",
+      "rarity": "uncommon",
+      "cooldown": 4,
+      "summary": "An aurora-lit tollkeeper flagged the headlights.",
+      "requires": { "regions": ["Manitoba", "Ontario", "Saskatchewan", "Alberta", "Northwest Territories"] },
+      "stages": [
+        {
+          "id": "gate",
+          "text": "An aurora tollkeeper leans into the roadway, palm outstretched.",
+          "choices": [
+            {
+              "id": "pay",
+              "label": "Pay the toll",
+              "outcome": "You pass a thermos of cocoa and a crumpled twenty.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "aurora-ward",
+                  "kind": "hazard",
+                  "amount": -0.1,
+                  "duration": 3,
+                  "label": "Aurora blessing steadies hazards for a while.",
+                  "message": "Aurora blessing steadies hazards for a while."
+                },
+                { "type": "log", "message": "Paid the aurora tollkeeper and earned a smoother road." }
+              ]
+            },
+            {
+              "id": "argue",
+              "label": "Argue the rates",
+              "outcome": "You haggle while the lights shimmer overhead.",
+              "effects": [
+                { "type": "resources", "changes": { "snacks": -1 } },
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "hazardHints": true,
+                  "maxHazard": 0.35,
+                  "message": "The tollkeeper pointed toward gentler exits."
+                },
+                { "type": "log", "message": "Argued with the aurora tollkeeper and traded snacks for safer turns." }
+              ]
+            },
+            {
+              "id": "drive",
+              "label": "Drive through",
+              "outcome": "You edge past the spectral booth without stopping.",
+              "effects": [
+                { "type": "resources", "changes": { "ride": -1 } },
+                { "type": "log", "message": "Shouldered past the aurora tollkeeper and took a hit to the ride." }
+              ],
+              "roll": {
+                "chance": 0.3,
+                "success": {
+                  "outcome": "Aurora sparks cling to the bumper in protection.",
+                  "effects": [
+                    {
+                      "type": "addBuff",
+                      "id": "aurora-veil",
+                      "kind": "hazard",
+                      "amount": -0.05,
+                      "duration": 2,
+                      "label": "Aurora sparks cling to the chassis.",
+                      "message": "Aurora sparks cling to the chassis for a couple of hops."
+                    },
+                    { "type": "log", "message": "Aurora sparks clung to the bumper and softened the next stretch." }
+                  ]
+                },
+                "failure": {
+                  "outcome": "The tollkeeper curses the bumper with a crackle.",
+                  "effects": [
+                    { "type": "log", "message": "The aurora tollkeeper crackled at the bumper after the snub." }
+                  ]
                 }
               }
             }
@@ -53,30 +456,57 @@
       ]
     },
     {
-      "id": "truckers-kindness",
-      "title": "Friendly Convoy",
-      "when": ["travel"],
-      "weight": 1,
-      "requires": { "minDay": 2 },
+      "id": "time-thunder-bay",
+      "title": "Time in Thunder Bay",
+      "hook": "travel",
+      "rarity": "uncommon",
+      "cooldown": 3,
+      "summary": "Time warped gently around Thunder Bay.",
+      "requires": { "regions": ["Ontario"] },
       "stages": [
         {
-          "text": "A pair of prairie truckers wave you into a rest stop, offering thermoses and tales of black ice ahead.",
+          "id": "bend",
+          "text": "Thunder Bay's skyline ripples; time itself offers a handshake.",
           "choices": [
             {
-              "id": "share",
-              "label": "Share stories and supplies",
-              "outcome": "You swap road stories and recipes for bannock.",
-              "effects": {
-                "resources": { "snacks": 2 },
-                "log": "The truckers restock your snack bin with jerky and Nanaimo bars." }
+              "id": "go",
+              "label": "Go with it",
+              "outcome": "You let the hours flow backward around the van.",
+              "effects": [
+                { "type": "dayShift", "days": -1, "message": "Time credited a day back." },
+                { "type": "resources", "changes": { "gas": 1 } },
+                { "type": "log", "message": "Let Thunder Bay bend time and gained a day and a splash of gas." }
+              ]
             },
             {
-              "id": "buy",
-              "label": "Buy extra gas cans",
-              "outcome": "You trade some cash for a tidy jerrycan.",
-              "effects": {
-                "resources": { "gas": 2, "money": -10 },
-                "log": "A spare jerrycan sloshes in the trunk." }
+              "id": "resist",
+              "label": "Resist the pull",
+              "outcome": "You grip the wheel until the ripple passes.",
+              "effects": [
+                { "type": "log", "message": "Resisted Thunder Bay's time ripple and kept the schedule steady." }
+              ]
+            },
+            {
+              "id": "exploit",
+              "label": "Exploit the loop",
+              "outcome": "You study every exit while the loop holds.",
+              "effects": [
+                {
+                  "type": "addBuff",
+                  "id": "thunderbay-preview",
+                  "kind": "preview-tight",
+                  "duration": 1,
+                  "label": "Time loop sharpened the next preview.",
+                  "message": "Time loop sharpened the next preview."
+                },
+                {
+                  "type": "revealNeighbors",
+                  "target": "destination",
+                  "hazardHints": true,
+                  "message": "You memorized every neighboring route."
+                },
+                { "type": "log", "message": "Exploited the Thunder Bay loop and charted every nearby route." }
+              ]
             }
           ]
         }

--- a/styles.css
+++ b/styles.css
@@ -413,6 +413,97 @@ legend {
   font-weight: 500;
 }
 
+.travel-banner-slot {
+  width: 100%;
+  padding-block: clamp(0.5rem, 2vw, 1rem) clamp(0.25rem, 1.5vw, 0.75rem);
+  padding-inline: calc(clamp(0.75rem, 3vw, 1.5rem) + env(safe-area-inset-left))
+    calc(clamp(0.75rem, 3vw, 1.5rem) + env(safe-area-inset-right));
+}
+
+.travel-banner {
+  background: linear-gradient(135deg, rgba(8, 40, 78, 0.92), rgba(5, 21, 45, 0.92));
+  border: 1px solid rgba(144, 195, 255, 0.24);
+  border-radius: var(--radius-md);
+  box-shadow: 0 1.5rem 3rem rgba(2, 10, 20, 0.5);
+  padding: clamp(0.9rem, 2vw, 1.35rem);
+  color: #f4fbff;
+  display: grid;
+  gap: clamp(0.5rem, 2vw, 0.9rem);
+}
+
+.travel-banner-title {
+  margin: 0;
+  font-size: clamp(1.05rem, 3vw, 1.25rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.travel-banner-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(225, 240, 255, 0.92);
+}
+
+.travel-banner-choices {
+  display: grid;
+  gap: clamp(0.4rem, 2vw, 0.75rem);
+}
+
+.travel-banner-choice {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #f4fbff;
+  border-radius: var(--radius-sm);
+  padding: clamp(0.65rem, 2vw, 0.85rem);
+  font-weight: 600;
+  text-align: left;
+  box-shadow: 0 0.75rem 1.5rem rgba(3, 18, 36, 0.38);
+}
+
+.travel-banner-choice:hover,
+.travel-banner-choice:focus-visible {
+  border-color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.travel-banner-choice:disabled {
+  opacity: 0.65;
+}
+
+.travel-banner-outcome {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(214, 236, 255, 0.92);
+  min-height: 1.2em;
+}
+
+.travel-banner-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.travel-banner-continue {
+  background: var(--color-accent);
+  color: #201109;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: clamp(0.55rem, 2vw, 0.75rem) clamp(1rem, 4vw, 1.5rem);
+  font-weight: 700;
+  box-shadow: 0 0.75rem 1.5rem rgba(239, 108, 51, 0.35);
+}
+
+.travel-banner-continue:hover,
+.travel-banner-continue:focus-visible {
+  background: #f47d4b;
+}
+
+.travel-banner-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(214, 236, 255, 0.82);
+}
+
 .map-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(260px, 24rem);
@@ -535,6 +626,12 @@ legend {
   margin: 0;
   font-size: 0.78rem;
   color: rgba(226, 239, 255, 0.82);
+}
+
+.map-preview-note {
+  margin: 0 0 var(--space-2);
+  color: rgba(221, 236, 255, 0.78);
+  font-size: 0.78rem;
 }
 
 .map-preview-yields p strong {

--- a/systems/events.js
+++ b/systems/events.js
@@ -1,130 +1,479 @@
 import { loadJSON } from './jsonLoader.js';
 
+const RARITY_WEIGHTS = {
+  common: 6,
+  uncommon: 3,
+  rare: 1
+};
+
 function clone(data) {
   return JSON.parse(JSON.stringify(data));
 }
 
-function evaluateConditions(event, snapshot) {
-  if (!event.when || !snapshot) {
-    return true;
-  }
-  const { requires = {} } = event;
-  if (requires.minDay && snapshot.day < requires.minDay) {
-    return false;
-  }
-  if (requires.maxDay && snapshot.day > requires.maxDay) {
-    return false;
-  }
-  if (Array.isArray(requires.visited) && requires.visited.length) {
-    const visitedAll = requires.visited.every((nodeId) => snapshot.visited?.includes(nodeId));
-    if (!visitedAll) {
-      return false;
-    }
-  }
-  return true;
-}
-
-function mergeEffects(base = {}, extra = {}) {
-  const result = clone(base);
-  if (extra.resources) {
-    result.resources = { ...(result.resources || {}) };
-    Object.entries(extra.resources).forEach(([key, value]) => {
-      result.resources[key] = (result.resources[key] || 0) + value;
-    });
-  }
-  if (extra.flags) {
-    result.flags = { ...(result.flags || {}) };
-    Object.entries(extra.flags).forEach(([key, value]) => {
-      result.flags[key] = value;
-    });
-  }
-  if (extra.log) {
-    result.log = [result.log, extra.log].filter(Boolean).join(' ');
-  }
-  return result;
+function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
 }
 
 export class EventEngine {
   constructor() {
-    this.events = [];
+    this.events = new Map();
   }
 
   async initialize() {
     const data = await loadJSON('../data/events.json');
-    this.events = Array.isArray(data.events) ? data.events : [];
+    const list = ensureArray(data.events);
+    list.forEach((event) => {
+      if (!event || !event.id) {
+        return;
+      }
+      const normalized = this._normalizeEvent(event);
+      this.events.set(normalized.id, normalized);
+    });
   }
 
-  findEvent(eventId) {
-    return this.events.find((event) => event.id === eventId);
+  _normalizeEvent(event) {
+    const stages = ensureArray(event.stages).map((stage, stageIndex) => {
+      const stageId = stage.id || `stage-${stageIndex}`;
+      const choices = ensureArray(stage.choices).map((choice, choiceIndex) => ({
+        ...choice,
+        id: choice.id || `${stageId}-choice-${choiceIndex}`
+      }));
+      return {
+        ...stage,
+        id: stageId,
+        choices
+      };
+    });
+    const stageMap = new Map();
+    stages.forEach((stage) => {
+      stageMap.set(stage.id, stage);
+    });
+    return {
+      ...event,
+      hook: event.hook || 'arrival',
+      rarity: event.rarity || 'common',
+      cooldown: typeof event.cooldown === 'number' ? event.cooldown : 0,
+      stages,
+      stageMap,
+      requires: event.requires || {}
+    };
   }
 
-  maybeTrigger(trigger, gameState) {
+  maybeTrigger(hook, gameState, context = {}) {
     if (!gameState?.state) {
       return null;
     }
     const snapshot = gameState.getSnapshot();
-    const candidates = this.events.filter((event) => {
-      if (!Array.isArray(event.when) || !event.when.includes(trigger)) {
-        return false;
+    const eligible = [];
+    this.events.forEach((event) => {
+      if (event.hook !== hook) {
+        return;
       }
-      return evaluateConditions(event, snapshot);
+      if (!this._passesRequirements(event, gameState, snapshot, context)) {
+        return;
+      }
+      eligible.push(event);
     });
-    if (!candidates.length) {
+    if (!eligible.length) {
       return null;
     }
-    const weights = candidates.map((event) => Number(event.weight) || 1);
-    const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
-    let threshold = gameState.rng.nextRange(0, totalWeight);
-    for (let index = 0; index < candidates.length; index += 1) {
-      threshold -= weights[index];
-      if (threshold <= 0) {
-        return clone(candidates[index]);
+    const weights = eligible.map((event) => {
+      if (typeof event.weight === 'number') {
+        return Math.max(0, event.weight);
       }
+      return RARITY_WEIGHTS[event.rarity] || 1;
+    });
+    const picked = this._pickWeighted(gameState, eligible, weights);
+    if (!picked) {
+      return null;
     }
-    return clone(candidates[candidates.length - 1]);
+    gameState.recordEncounterTrigger(picked.id);
+    if (picked.summary) {
+      gameState.appendLog(picked.summary);
+    }
+    const stage = this._getStage(picked, picked.entryStage || picked.stages[0]?.id);
+    if (!stage) {
+      return null;
+    }
+    return {
+      id: picked.id,
+      title: picked.title,
+      hook: picked.hook,
+      stage: this._cloneStage(stage),
+      stageId: stage.id,
+      context: { ...context }
+    };
   }
 
-  resolveChoice(eventId, choiceId, gameState) {
-    const event = this.findEvent(eventId);
+  _getStage(event, stageId) {
+    if (!event) {
+      return null;
+    }
+    if (stageId && event.stageMap.has(stageId)) {
+      return event.stageMap.get(stageId);
+    }
+    return event.stages[0] || null;
+  }
+
+  _cloneStage(stage) {
+    return stage ? clone(stage) : null;
+  }
+
+  resolveChoice(eventId, stageId, choiceId, gameState, context = {}) {
+    const event = this.events.get(eventId);
     if (!event) {
       throw new Error(`Unknown event: ${eventId}`);
     }
-    const stage = event.stages?.[0];
+    const stage = this._getStage(event, stageId);
     if (!stage) {
-      throw new Error(`Event ${eventId} is missing stages`);
+      throw new Error(`Unknown stage ${stageId} for event ${eventId}`);
     }
-    const choice = stage.choices?.find((entry) => entry.id === choiceId);
+    const choice = stage.choices.find((entry) => entry.id === choiceId);
     if (!choice) {
-      throw new Error(`Unknown choice ${choiceId} for event ${eventId}`);
+      throw new Error(`Unknown choice ${choiceId} for stage ${stageId}`);
     }
 
-    let effects = mergeEffects({}, choice.effects || {});
-    let resultText = choice.outcome || '';
-    let success = null;
-    let rollValue = null;
+    const outcomeParts = [];
+    if (choice.outcome) {
+      outcomeParts.push(choice.outcome);
+    }
+    if (choice.log) {
+      gameState.appendLog(choice.log);
+    }
 
+    ensureArray(choice.effects).forEach((effect) => {
+      const message = this._applyEffect(effect, { event, stage, choice, gameState, context });
+      if (message) {
+        outcomeParts.push(message);
+      }
+    });
+
+    let rollResult = null;
     if (choice.roll) {
       const chance = typeof choice.roll.chance === 'number' ? choice.roll.chance : 0.5;
-      rollValue = gameState.rng.nextFloat();
-      success = rollValue <= chance;
+      const roll = gameState.rng.nextFloat();
+      const success = roll <= chance;
       const branch = success ? choice.roll.success : choice.roll.failure;
       if (branch) {
-        effects = mergeEffects(effects, branch.effects || {});
-        resultText = [resultText, branch.outcome].filter(Boolean).join(' ');
+        if (branch.outcome) {
+          outcomeParts.push(branch.outcome);
+        }
+        ensureArray(branch.effects).forEach((effect) => {
+          const message = this._applyEffect(effect, { event, stage, choice, gameState, context });
+          if (message) {
+            outcomeParts.push(message);
+          }
+        });
       }
+      rollResult = { roll, success };
     }
 
-    if (effects.log && !resultText) {
-      resultText = effects.log;
-    }
+    this._applyChoiceFlags(choice, gameState);
 
-    gameState.applyEffects(effects);
+    const nextStageId = choice.nextStage || null;
+    const nextStage = nextStageId ? this._getStage(event, nextStageId) : null;
 
     return {
-      success,
-      roll: rollValue,
-      outcome: resultText,
-      applied: effects
+      outcome: outcomeParts.join(' ').trim(),
+      nextStage: this._cloneStage(nextStage),
+      nextStageId: nextStage?.id || null,
+      done: !nextStage,
+      roll: rollResult
     };
+  }
+
+  _applyChoiceFlags(choice, gameState) {
+    const setters = choice.setFlags;
+    if (Array.isArray(setters)) {
+      setters.forEach((flag) => {
+        gameState.setEncounterFlag(flag, true);
+      });
+    } else if (setters && typeof setters === 'object') {
+      Object.entries(setters).forEach(([flag, value]) => {
+        gameState.setEncounterFlag(flag, value !== undefined ? value : true);
+      });
+    }
+    const clearers = choice.clearFlags;
+    if (Array.isArray(clearers)) {
+      clearers.forEach((flag) => {
+        gameState.clearEncounterFlag(flag);
+      });
+    }
+  }
+
+  _applyEffect(effect, context) {
+    if (!effect || typeof effect !== 'object') {
+      return null;
+    }
+    const { gameState, event, stage, choice } = context;
+    const encounterContext = context.context;
+    switch (effect.type) {
+      case 'resources': {
+        const changes = effect.changes || effect.resources || {};
+        gameState.adjustResources(changes);
+        return effect.message || null;
+      }
+      case 'log': {
+        if (effect.message) {
+          gameState.appendLog(effect.message);
+        }
+        return null;
+      }
+      case 'dayShift':
+      case 'days': {
+        const delta = typeof effect.days === 'number' ? effect.days : effect.amount;
+        if (typeof delta === 'number' && delta) {
+          gameState.shiftDays(delta);
+        }
+        return effect.message || null;
+      }
+      case 'revealNeighbors': {
+        const targetId = this._resolveTargetNodeId(effect.target, gameState, encounterContext);
+        if (!targetId) {
+          return null;
+        }
+        const options = {};
+        if (effect.hazardHints) {
+          options.hazardHints = true;
+        }
+        if (typeof effect.maxHazard === 'number') {
+          options.filter = (connection) => {
+            const hazard = typeof connection.hazard === 'number' ? connection.hazard : 0;
+            return hazard <= effect.maxHazard;
+          };
+        }
+        const revealed = gameState.revealNeighbors(targetId, options);
+        if (effect.message) {
+          return effect.message.replace('{count}', revealed.length);
+        }
+        return null;
+      }
+      case 'revealHazards': {
+        const targetId = this._resolveTargetNodeId(effect.target, gameState, encounterContext);
+        if (!targetId) {
+          return null;
+        }
+        const revealed = gameState.revealNeighbors(targetId, { hazardHints: true });
+        if (effect.message) {
+          return effect.message.replace('{count}', revealed.length);
+        }
+        return null;
+      }
+      case 'setFlag': {
+        if (effect.flag) {
+          gameState.setEncounterFlag(effect.flag, effect.value !== undefined ? effect.value : true);
+        }
+        return effect.message || null;
+      }
+      case 'clearFlag': {
+        if (effect.flag) {
+          gameState.clearEncounterFlag(effect.flag);
+        }
+        return effect.message || null;
+      }
+      case 'addBuff': {
+        const baseId = effect.id || `${event.id}-${stage.id}-${choice.id}-${effect.kind || 'buff'}`;
+        gameState.addEncounterBuff({
+          id: baseId,
+          kind: effect.kind || 'generic',
+          amount: typeof effect.amount === 'number' ? effect.amount : (typeof effect.value === 'number' ? effect.value : 0),
+          remaining: typeof effect.remaining === 'number' ? effect.remaining : undefined,
+          duration: effect.duration,
+          tick: effect.tick || (effect.kind === 'skip-hazard' ? 'manual' : 'travel'),
+          label: effect.label || null,
+          meta: effect.meta || {}
+        });
+        return effect.message || null;
+      }
+      case 'clearBuff': {
+        if (effect.id) {
+          gameState.removeEncounterBuff(effect.id);
+        }
+        if (effect.kind) {
+          const buffs = gameState.getEncounterBuffs();
+          buffs.forEach((buff) => {
+            if (buff.kind === effect.kind) {
+              gameState.removeEncounterBuff(buff.id);
+            }
+          });
+        }
+        return effect.message || null;
+      }
+      case 'teleport': {
+        const targetId = this._resolveTeleportTarget(effect, gameState, encounterContext);
+        if (targetId) {
+          gameState.teleportTo(targetId, { dayShift: effect.dayShift || 0, log: effect.log });
+          if (effect.revealNeighbors) {
+            gameState.revealNeighbors(targetId, { hazardHints: Boolean(effect.hazardHints) });
+          }
+          return effect.message || null;
+        }
+        return null;
+      }
+      default:
+        return null;
+    }
+  }
+
+  _resolveTargetNodeId(target, gameState, context) {
+    const fallback = gameState.state?.location || null;
+    if (!target) {
+      return fallback;
+    }
+    if (typeof target === 'string' && target.startsWith('node:')) {
+      return target.slice(5);
+    }
+    if (typeof target === 'string') {
+      switch (target) {
+        case 'current':
+        case 'here':
+          return gameState.state?.location || null;
+        case 'origin':
+        case 'from':
+          return context?.fromNodeId || context?.originId || null;
+        case 'destination':
+        case 'arrival':
+        case 'to':
+          return context?.toNodeId || context?.nodeId || gameState.state?.location || null;
+        default:
+          return target;
+      }
+    }
+    return fallback;
+  }
+
+  _resolveTeleportTarget(effect, gameState, context) {
+    const graph = gameState.getWorldGraph();
+    if (!graph) {
+      return null;
+    }
+    if (effect.targetId) {
+      return effect.targetId;
+    }
+    const originId = this._resolveTargetNodeId(effect.origin || effect.target || 'current', gameState, context);
+    const origin = originId ? graph.nodes.get(originId) : null;
+    if (!origin || !Array.isArray(origin.connections)) {
+      return null;
+    }
+    const candidates = origin.connections
+      .map((connection) => ({
+        connection,
+        node: graph.nodes.get(connection.id)
+      }))
+      .filter((entry) => Boolean(entry.node));
+    if (!candidates.length) {
+      return null;
+    }
+    if (effect.mode === 'forward') {
+      const ordered = candidates
+        .slice()
+        .sort((a, b) => {
+          const distanceA = typeof a.connection.distance === 'number' ? a.connection.distance : 1;
+          const distanceB = typeof b.connection.distance === 'number' ? b.connection.distance : 1;
+          return distanceB - distanceA;
+        });
+      const unvisited = ordered.find((entry) => !gameState.state.visited?.includes(entry.node.id));
+      return (unvisited || ordered[0])?.node?.id || null;
+    }
+    const pool = candidates;
+    if (!pool.length) {
+      return null;
+    }
+    const index = Math.floor(gameState.rng.nextRange(0, pool.length));
+    const chosen = pool[index] || pool[pool.length - 1];
+    return chosen?.node?.id || null;
+  }
+
+  _passesRequirements(event, gameState, snapshot, context) {
+    const day = snapshot?.day ?? 0;
+    if (event.cooldown > 0) {
+      const last = gameState.getEncounterCooldown(event.id);
+      if (last && typeof last.day === 'number') {
+        const elapsed = day - last.day;
+        if (elapsed >= 0 && elapsed < event.cooldown) {
+          return false;
+        }
+      }
+    }
+    const requires = event.requires || {};
+    if (typeof requires.minDay === 'number' && day < requires.minDay) {
+      return false;
+    }
+    if (typeof requires.maxDay === 'number' && day > requires.maxDay) {
+      return false;
+    }
+    const region = this._resolveRegion(context, gameState);
+    if (requires.regions && requires.regions.length) {
+      if (!region || !requires.regions.includes(region)) {
+        return false;
+      }
+    }
+    if (requires.notRegions && requires.notRegions.length) {
+      if (region && requires.notRegions.includes(region)) {
+        return false;
+      }
+    }
+    if (Array.isArray(requires.flags)) {
+      const hasAll = requires.flags.every((flag) => gameState.hasEncounterFlag(flag));
+      if (!hasAll) {
+        return false;
+      }
+    }
+    if (Array.isArray(requires.notFlags)) {
+      const blocked = requires.notFlags.some((flag) => gameState.hasEncounterFlag(flag));
+      if (blocked) {
+        return false;
+      }
+    }
+    if (Array.isArray(requires.contextTags) && requires.contextTags.length) {
+      const tags = Array.isArray(context.tags) ? context.tags : [];
+      const ok = requires.contextTags.every((tag) => tags.includes(tag));
+      if (!ok) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  _resolveRegion(context, gameState) {
+    if (context?.region) {
+      return context.region;
+    }
+    if (context?.node?.region) {
+      return context.node.region;
+    }
+    if (context?.toNode?.region) {
+      return context.toNode.region;
+    }
+    const graph = gameState.getWorldGraph();
+    if (!graph) {
+      return null;
+    }
+    if (context?.nodeId && graph.nodes.has(context.nodeId)) {
+      return graph.nodes.get(context.nodeId).region || null;
+    }
+    if (context?.toNodeId && graph.nodes.has(context.toNodeId)) {
+      return graph.nodes.get(context.toNodeId).region || null;
+    }
+    const currentId = gameState.state?.location;
+    if (currentId && graph.nodes.has(currentId)) {
+      return graph.nodes.get(currentId).region || null;
+    }
+    return null;
+  }
+
+  _pickWeighted(gameState, entries, weights) {
+    const total = weights.reduce((sum, weight) => sum + Math.max(0, Number(weight) || 0), 0);
+    if (total <= 0) {
+      return null;
+    }
+    let threshold = gameState.rng.nextRange(0, total);
+    for (let index = 0; index < entries.length; index += 1) {
+      threshold -= Math.max(0, Number(weights[index]) || 0);
+      if (threshold <= 0) {
+        return entries[index];
+      }
+    }
+    return entries[entries.length - 1] || null;
   }
 }

--- a/ui/EventModal.js
+++ b/ui/EventModal.js
@@ -8,6 +8,10 @@ export default class EventModal {
     this.currentEvent = null;
     this.choiceHandler = null;
     this.closeHandler = null;
+    this.stage = null;
+    this.bodyElement = null;
+    this.choiceGrid = null;
+    this.outcomeElement = null;
   }
 
   open(eventData, { onChoice, onClose } = {}) {
@@ -32,33 +36,15 @@ export default class EventModal {
     this.modal.append(title);
 
     const body = document.createElement('p');
-    body.textContent = eventData.stages?.[0]?.text || eventData.text || '';
+    body.className = 'modal-body';
+    body.textContent = '';
     this.modal.append(body);
+    this.bodyElement = body;
 
     const choiceGrid = document.createElement('div');
     choiceGrid.className = 'choice-grid';
-    const stage = eventData.stages?.[0];
-    const choices = stage?.choices || [];
-    choices.forEach((choice) => {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.textContent = choice.label;
-      button.dataset.choiceId = choice.id;
-      button.addEventListener('click', () => {
-        if (typeof this.choiceHandler === 'function') {
-          this.choiceHandler(choice);
-        }
-      });
-      choiceGrid.append(button);
-    });
-
-    if (!choices.length) {
-      const noop = document.createElement('p');
-      noop.textContent = 'There are no choices defined for this encounter yet.';
-      choiceGrid.append(noop);
-    }
-
     this.modal.append(choiceGrid);
+    this.choiceGrid = choiceGrid;
 
     const footer = document.createElement('div');
     footer.className = 'modal-footer';
@@ -73,6 +59,7 @@ export default class EventModal {
     outcome.className = 'modal-outcome';
     outcome.setAttribute('aria-live', 'polite');
     footer.append(outcome);
+    this.outcomeElement = outcome;
 
     this.modal.append(footer);
 
@@ -87,20 +74,65 @@ export default class EventModal {
     document.addEventListener('keydown', this._handleEscape);
 
     trapFocus(this.modal);
+
+    const initialStage = eventData.stage || eventData.stages?.[0] || null;
+    this.setStage(initialStage);
   }
 
-  showOutcome(text) {
+  showOutcome(text, { lock = true } = {}) {
     if (!this.modal) {
       return;
     }
-    const outcome = this.modal.querySelector('.modal-outcome');
-    if (outcome) {
-      outcome.textContent = text;
+    if (this.outcomeElement) {
+      this.outcomeElement.textContent = text || '';
     }
-    const buttons = this.modal.querySelectorAll('.choice-grid button');
-    buttons.forEach((button) => {
-      button.disabled = true;
+    if (lock && this.choiceGrid) {
+      const buttons = this.choiceGrid.querySelectorAll('button');
+      buttons.forEach((button) => {
+        button.disabled = true;
+      });
+    }
+  }
+
+  setStage(stage) {
+    this.stage = stage || null;
+    if (!this.modal) {
+      return;
+    }
+    if (this.outcomeElement) {
+      this.outcomeElement.textContent = '';
+    }
+    if (this.bodyElement) {
+      const text = this.stage?.text || this.currentEvent?.text || '';
+      this.bodyElement.textContent = text;
+    }
+    if (!this.choiceGrid) {
+      return;
+    }
+    this.choiceGrid.innerHTML = '';
+    const choices = this.stage?.choices || [];
+    if (!choices.length) {
+      const message = document.createElement('p');
+      message.textContent = 'No decisions remain here.';
+      this.choiceGrid.append(message);
+      return;
+    }
+    choices.forEach((choice) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = choice.label;
+      button.dataset.choiceId = choice.id;
+      button.addEventListener('click', () => {
+        if (typeof this.choiceHandler === 'function') {
+          this.choiceHandler(this.stage, choice);
+        }
+      });
+      this.choiceGrid.append(button);
     });
+    const firstButton = this.choiceGrid.querySelector('button');
+    if (firstButton && typeof firstButton.focus === 'function') {
+      firstButton.focus({ preventScroll: true });
+    }
   }
 
   close() {
@@ -114,6 +146,10 @@ export default class EventModal {
     this.backdrop.remove();
     this.backdrop = null;
     this.modal = null;
+    this.bodyElement = null;
+    this.choiceGrid = null;
+    this.outcomeElement = null;
+    this.stage = null;
     const callback = this.closeHandler;
     this.closeHandler = null;
     if (typeof callback === 'function') {

--- a/ui/TravelBanner.js
+++ b/ui/TravelBanner.js
@@ -1,0 +1,161 @@
+export default class TravelBanner {
+  constructor(container) {
+    this.container = container;
+    this.root = null;
+    this.titleElement = null;
+    this.textElement = null;
+    this.choiceList = null;
+    this.outcomeElement = null;
+    this.continueButton = null;
+    this.encounter = null;
+    this.stage = null;
+    this.onChoice = null;
+    this.onComplete = null;
+  }
+
+  open(encounter, handlers = {}) {
+    this.close();
+    this.encounter = encounter;
+    this.onChoice = handlers.onChoice || null;
+    this.onComplete = handlers.onComplete || null;
+
+    this.root = document.createElement('section');
+    this.root.className = 'travel-banner';
+    this.root.setAttribute('role', 'region');
+    this.root.setAttribute('aria-live', 'polite');
+    this.root.tabIndex = -1;
+
+    const heading = document.createElement('h3');
+    heading.className = 'travel-banner-title';
+    heading.textContent = encounter.title || 'Roadside encounter';
+
+    const text = document.createElement('p');
+    text.className = 'travel-banner-text';
+
+    const choiceList = document.createElement('div');
+    choiceList.className = 'travel-banner-choices';
+
+    const outcome = document.createElement('p');
+    outcome.className = 'travel-banner-outcome';
+    outcome.setAttribute('aria-live', 'polite');
+
+    const controls = document.createElement('div');
+    controls.className = 'travel-banner-controls';
+
+    const continueButton = document.createElement('button');
+    continueButton.type = 'button';
+    continueButton.className = 'travel-banner-continue';
+    continueButton.textContent = 'Continue';
+    continueButton.hidden = true;
+    continueButton.addEventListener('click', () => {
+      if (typeof this.onComplete === 'function') {
+        this.onComplete();
+      }
+    });
+    controls.append(continueButton);
+
+    this.root.append(heading, text, choiceList, outcome, controls);
+
+    if (this.container) {
+      this.container.innerHTML = '';
+      this.container.append(this.root);
+    }
+
+    this.titleElement = heading;
+    this.textElement = text;
+    this.choiceList = choiceList;
+    this.outcomeElement = outcome;
+    this.continueButton = continueButton;
+
+    this.setStage(encounter.stage);
+    this.root.focus({ preventScroll: true });
+  }
+
+  setStage(stage) {
+    this.stage = stage || null;
+    if (this.encounter) {
+      this.encounter.stage = this.stage;
+    }
+    if (this.outcomeElement) {
+      this.outcomeElement.textContent = '';
+    }
+    if (this.continueButton) {
+      this.continueButton.hidden = true;
+      this.continueButton.disabled = false;
+    }
+    if (this.textElement) {
+      const text = this.stage?.text || this.encounter?.text || '';
+      this.textElement.textContent = text;
+    }
+    if (!this.choiceList) {
+      return;
+    }
+    this.choiceList.innerHTML = '';
+    const choices = this.stage?.choices || [];
+    if (!choices.length) {
+      const message = document.createElement('p');
+      message.className = 'travel-banner-note';
+      message.textContent = 'Nothing more to decide here.';
+      this.choiceList.append(message);
+      if (this.continueButton) {
+        this.continueButton.hidden = false;
+        this.continueButton.focus({ preventScroll: true });
+      }
+      return;
+    }
+    choices.forEach((choice) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'travel-banner-choice';
+      button.textContent = choice.label;
+      button.dataset.choiceId = choice.id;
+      button.addEventListener('click', () => {
+        if (typeof this.onChoice === 'function') {
+          this.onChoice(stage, choice);
+        }
+      });
+      this.choiceList.append(button);
+    });
+    const firstButton = this.choiceList.querySelector('button');
+    if (firstButton && typeof firstButton.focus === 'function') {
+      firstButton.focus({ preventScroll: true });
+    }
+  }
+
+  showOutcome(text, { final = false } = {}) {
+    if (this.outcomeElement) {
+      this.outcomeElement.textContent = text || '';
+    }
+    if (this.choiceList && final) {
+      const buttons = this.choiceList.querySelectorAll('button');
+      buttons.forEach((button) => {
+        button.disabled = true;
+      });
+    }
+    if (this.continueButton) {
+      if (final) {
+        this.continueButton.hidden = false;
+        this.continueButton.disabled = false;
+        this.continueButton.focus({ preventScroll: true });
+      } else {
+        this.continueButton.hidden = true;
+      }
+    }
+  }
+
+  close() {
+    if (this.root) {
+      this.root.remove();
+    }
+    this.root = null;
+    this.titleElement = null;
+    this.textElement = null;
+    this.choiceList = null;
+    this.outcomeElement = null;
+    this.continueButton = null;
+    this.encounter = null;
+    this.stage = null;
+    this.onChoice = null;
+    this.onComplete = null;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the ad-hoc event loader with a deterministic encounter engine that supports travel and arrival hooks, rarity, cooldowns, and effect dispatch
- extend game state with encounter tracking, travel preview modifiers, and hazard/buff handling
- integrate encounters into the map flow with a travel banner, multi-stage arrival modal support, and styles
- author a surreal Canadian event pack covering Ogopogo, Wendigo Radio, the Hotel Beneath the Snow, Voyageurs’ Ghost Canoe, the Aurora Tollkeeper, and Time in Thunder Bay

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca824b8c848320aba2ca0f3dfe3a87