### PR TITLE
Keep travel confirmation card visible until action

### DIFF
--- a/ui/MapScreen.js
+++ b/ui/MapScreen.js
@@ -1346,8 +1346,11 @@ export default class MapScreen {
     }
   }
 
-  _hidePreview() {
+  _hidePreview(force = false) {
     if (!this.previewCard) {
+      return;
+    }
+    if (!force && this.previewCard.dataset.mode === 'confirm') {
       return;
     }
     this.previewCard.dataset.visible = 'false';
@@ -1370,12 +1373,12 @@ export default class MapScreen {
     if (this.activePreviewTarget !== nodeId) {
       return;
     }
-    this._hidePreview();
+    this._hidePreview(true);
   }
 
   _dismissTravelPreview() {
     const targetId = this.pendingTravelNodeId;
-    this._hidePreview();
+    this._hidePreview(true);
     if (!targetId || !this.mapArea) {
       return;
     }
@@ -1408,7 +1411,7 @@ export default class MapScreen {
 
     const result = this.gameState.travelTo(nodeId);
 
-    this._hidePreview();
+    this._hidePreview(true);
     this._refresh();
 
     const arrivalContext = {


### PR DESCRIPTION
## Summary
- prevent the map travel preview from hiding itself while in confirmation mode
- ensure dismiss and confirm paths explicitly close the card when appropriate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca8a71ea9c83208768f30d8a5a84dd