### PR TITLE
Prevent peek previews from closing travel confirmation

### DIFF
--- a/ui/MapScreen.js
+++ b/ui/MapScreen.js
@@ -1210,6 +1210,9 @@ export default class MapScreen {
 
   _maybePreviewNode(nodeId) {
     const snapshot = this.currentSnapshot;
+    if (this.previewCard?.dataset.mode === 'confirm') {
+      return;
+    }
     if (this.suppressPeekTarget === nodeId) {
       this.suppressPeekTarget = null;
       return;
@@ -1346,8 +1349,11 @@ export default class MapScreen {
     }
   }
 
-  _hidePreview() {
+  _hidePreview(force = false) {
     if (!this.previewCard) {
+      return;
+    }
+    if (!force && this.previewCard.dataset.mode === 'confirm') {
       return;
     }
     this.previewCard.dataset.visible = 'false';
@@ -1370,12 +1376,12 @@ export default class MapScreen {
     if (this.activePreviewTarget !== nodeId) {
       return;
     }
-    this._hidePreview();
+    this._hidePreview(true);
   }
 
   _dismissTravelPreview() {
     const targetId = this.pendingTravelNodeId;
-    this._hidePreview();
+    this._hidePreview(true);
     if (!targetId || !this.mapArea) {
       return;
     }
@@ -1408,7 +1414,7 @@ export default class MapScreen {
 
     const result = this.gameState.travelTo(nodeId);
 
-    this._hidePreview();
+    this._hidePreview(true);
     this._refresh();
 
     const arrivalContext = {


### PR DESCRIPTION
## Summary
- stop hover/focus peek previews from running while the confirmation card is open so it stays visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca8a71ea9c83208768f30d8a5a84dd