### PR TITLE
Keep travel confirmation card persistent

### DIFF
--- a/ui/MapScreen.js
+++ b/ui/MapScreen.js
@@ -704,6 +704,54 @@ export default class MapScreen {
     this._updateLocation(snapshot);
     this._updateLog(snapshot);
     this._drawCanvas();
+    this._restorePreview(snapshot);
+  }
+
+  _restorePreview(snapshot) {
+    if (!this.previewCard || this.previewCard.dataset.visible !== 'true') {
+      return;
+    }
+
+    const currentId = snapshot?.location;
+    if (!currentId) {
+      this._hidePreview(true);
+      return;
+    }
+
+    const ensureEstimate = (targetId) => {
+      if (!targetId) {
+        return null;
+      }
+      const isReachable = Array.isArray(this.activeConnections)
+        && this.activeConnections.some((entry) => entry.node.id === targetId);
+      if (!isReachable) {
+        return null;
+      }
+      return this.gameState.getTravelEstimate(currentId, targetId);
+    };
+
+    if (this.previewCard.dataset.mode === 'confirm') {
+      const targetId = this.pendingTravelNodeId;
+      const estimate = ensureEstimate(targetId);
+      if (!estimate) {
+        this._hidePreview(true);
+        return;
+      }
+      this._showPreview(estimate, { mode: 'confirm' });
+      return;
+    }
+
+    const activeTargetId = this.activePreviewTarget;
+    if (!activeTargetId) {
+      return;
+    }
+
+    const estimate = ensureEstimate(activeTargetId);
+    if (!estimate) {
+      this._hidePreview(true);
+      return;
+    }
+    this._showPreview(estimate, { mode: 'peek' });
   }
 
   _updateResourceBoard(snapshot) {
@@ -1210,6 +1258,9 @@ export default class MapScreen {
 
   _maybePreviewNode(nodeId) {
     const snapshot = this.currentSnapshot;
+    if (this.previewCard?.dataset.mode === 'confirm') {
+      return;
+    }
     if (this.suppressPeekTarget === nodeId) {
       this.suppressPeekTarget = null;
       return;
@@ -1346,8 +1397,11 @@ export default class MapScreen {
     }
   }
 
-  _hidePreview() {
+  _hidePreview(force = false) {
     if (!this.previewCard) {
+      return;
+    }
+    if (!force && this.previewCard.dataset.mode === 'confirm') {
       return;
     }
     this.previewCard.dataset.visible = 'false';
@@ -1370,12 +1424,12 @@ export default class MapScreen {
     if (this.activePreviewTarget !== nodeId) {
       return;
     }
-    this._hidePreview();
+    this._hidePreview(true);
   }
 
   _dismissTravelPreview() {
     const targetId = this.pendingTravelNodeId;
-    this._hidePreview();
+    this._hidePreview(true);
     if (!targetId || !this.mapArea) {
       return;
     }
@@ -1408,7 +1462,7 @@ export default class MapScreen {
 
     const result = this.gameState.travelTo(nodeId);
 
-    this._hidePreview();
+    this._hidePreview(true);
     this._refresh();
 
     const arrivalContext = {


### PR DESCRIPTION
## Summary
- stop hover/focus peek previews from running while the confirmation card is open so it stays visible
- restore the travel confirmation card after refreshes so it remains until confirmed or cancelled

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca8a71ea9c83208768f30d8a5a84dd