### PR TITLE
Polish title and setup screens for mobile-first hero layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,18 @@ body.map-mode .site-footer {
   display: none;
 }
 
+body.title-mode main#app {
+  padding: 0;
+  width: 100vw;
+  height: 100dvh;
+  align-items: stretch;
+}
+
+body.title-mode .site-header,
+body.title-mode .site-footer {
+  display: none;
+}
+
 main#app {
   flex: 1;
   padding: var(--space-4);
@@ -146,6 +158,51 @@ main#app {
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+}
+
+.title-screen {
+  min-height: 100dvh;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) max(env(safe-area-inset-bottom), 1rem) env(safe-area-inset-left);
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: 0;
+  width: 100%;
+  max-width: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.title-hero {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.title-hero img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.title-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0.15) 45%, transparent 70%);
+  pointer-events: none;
+}
+
+.title-hero-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(160deg, rgba(3, 14, 30, 0.8), rgba(13, 60, 112, 0.65) 55%, rgba(239, 108, 51, 0.45));
+}
+
+.title-cta {
+  display: grid;
+  gap: var(--space-4);
+  padding: 0 var(--space-4) max(env(safe-area-inset-bottom), 1rem) var(--space-4);
 }
 
 .screen-footer {
@@ -182,6 +239,7 @@ button {
   cursor: pointer;
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
   box-shadow: 0 0.75rem 1.5rem rgba(11, 109, 202, 0.22);
+  min-height: 44px;
 }
 
 button:hover,
@@ -248,6 +306,20 @@ legend {
   gap: var(--space-2);
 }
 
+.seed-row {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.seed-input-group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.seed-row button {
+  width: 100%;
+}
+
 .setup-form {
   display: grid;
   gap: var(--space-4);
@@ -259,9 +331,13 @@ legend {
   background: var(--color-surface-alt);
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  padding: var(--space-3);
+  padding: var(--space-4);
   cursor: pointer;
   transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+label.vehicle-card {
+  min-height: 120px;
 }
 
 .vehicle-card:hover,
@@ -283,8 +359,8 @@ legend {
 }
 
 .vehicle-card input[type='radio'] {
-  width: 1.75rem;
-  height: 1.75rem;
+  width: 2.75rem;
+  height: 2.75rem;
   margin: 0;
   flex: 0 0 auto;
   accent-color: var(--color-primary);
@@ -297,6 +373,10 @@ legend {
 .vehicle-card p {
   margin: 0;
   color: var(--color-text-muted);
+}
+
+.vehicle-card .inline-chips {
+  flex-wrap: wrap;
 }
 
 .vehicle-card-media {
@@ -326,6 +406,7 @@ legend {
 .vehicle-stats {
   font-weight: 600;
   color: var(--color-text);
+  overflow-wrap: anywhere;
 }
 
 @media (min-width: 720px) {
@@ -356,6 +437,18 @@ legend {
   }
 }
 
+@media (min-width: 640px) {
+  .seed-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+    gap: var(--space-3);
+  }
+
+  .seed-row button {
+    width: auto;
+  }
+}
+
 .inline-chips {
   display: flex;
   flex-wrap: wrap;
@@ -374,13 +467,42 @@ legend {
 .action-buttons {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: var(--space-4);
+}
+
+.setup-screen {
+  padding-bottom: max(env(safe-area-inset-bottom), 1rem);
+}
+
+.brand-lockup {
+  display: block;
+  max-width: 12rem;
+  width: 100%;
+  margin: 0 auto var(--space-4);
+}
+
+.setup-screen .brand-lockup {
+  filter: drop-shadow(0 0.5rem 1.25rem rgba(11, 109, 202, 0.18));
 }
 
 @media (min-width: 640px) {
   .action-buttons {
     flex-direction: row;
     justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button,
+  .vehicle-card {
+    transition: none;
+  }
+
+  button:hover,
+  button:focus-visible,
+  .vehicle-card:hover,
+  .vehicle-card:focus-within {
+    transform: none;
   }
 }
 

--- a/ui/SetupScreen.js
+++ b/ui/SetupScreen.js
@@ -22,6 +22,7 @@ export default class SetupScreen {
 
   async render() {
     await assets.load();
+    const lock = assets.get('ui.brand.lockup');
     const section = document.createElement('section');
     section.className = 'screen setup-screen';
     section.setAttribute('aria-labelledby', 'setup-screen-heading');
@@ -32,6 +33,14 @@ export default class SetupScreen {
       <h2 id="setup-screen-heading">Dial in your rig and seed</h2>
       <p>Choose a vehicle, lock in a seed, and roll out with the family already buckled in.</p>
     `;
+    if (lock?.src) {
+      const brand = document.createElement('img');
+      brand.src = lock.src;
+      brand.alt = 'Canadian Trail logo';
+      brand.className = 'brand-lockup';
+      brand.loading = 'lazy';
+      header.prepend(brand);
+    }
     section.append(header);
 
     const form = document.createElement('form');
@@ -119,7 +128,7 @@ export default class SetupScreen {
     form.append(vehicleFieldset);
 
     const seedRow = document.createElement('div');
-    seedRow.className = 'form-row';
+    seedRow.className = 'form-row seed-row';
     const seedLabel = document.createElement('label');
     seedLabel.setAttribute('for', 'seed');
     seedLabel.textContent = 'Seed';
@@ -144,7 +153,11 @@ export default class SetupScreen {
       seedInput.focus({ preventScroll: true });
     });
 
-    seedRow.append(seedLabel, seedInput, seedHelp, randomizeButton);
+    const seedField = document.createElement('div');
+    seedField.className = 'seed-input-group';
+    seedField.append(seedLabel, seedInput, seedHelp);
+
+    seedRow.append(seedField, randomizeButton);
     form.append(seedRow);
 
     const partyFieldset = document.createElement('fieldset');

--- a/ui/TitleScreen.js
+++ b/ui/TitleScreen.js
@@ -1,11 +1,21 @@
 import { assets } from '../systems/assets.js';
 
+const HERO_ALT_TEXT = 'Family van at dusk under northern lights';
+
 export default class TitleScreen {
   constructor({ screenManager, gameState }) {
     this.screenManager = screenManager;
     this.gameState = gameState;
     this.continueAvailable = false;
     this.continueButton = null;
+  }
+
+  activate() {
+    document.body.classList.add('title-mode');
+  }
+
+  deactivate() {
+    document.body.classList.remove('title-mode');
   }
 
   bind() {}
@@ -20,33 +30,42 @@ export default class TitleScreen {
 
   async render() {
     await assets.load();
-    const hero = assets.get('ui.hero');
+
+    const isPortrait = window.innerHeight >= window.innerWidth;
+    const heroKey = isPortrait ? 'ui.hero.portrait' : 'ui.hero.landscape';
+    const hero = assets.get(heroKey);
 
     const section = document.createElement('section');
     section.className = 'screen title-screen';
     section.setAttribute('aria-labelledby', 'title-screen-heading');
 
-    section.innerHTML = `
-      <div class="screen-header">
-        <h2 id="title-screen-heading">Pack up, family! We're heading Out There, Eh?</h2>
-        <p>Settle into a cozy Canadian road-trip roguelike. Every journey begins with a full thermos, a hopeful playlist, and a single seed for fate.</p>
-      </div>
-    `;
+    const heroWrapper = document.createElement('div');
+    heroWrapper.className = 'title-hero';
 
-    const media = document.createElement('div');
     if (hero?.src) {
       const img = document.createElement('img');
       img.src = hero.src;
-      img.alt = hero.alt || 'Illustration of a van cresting a snowy hill';
-      img.className = 'placeholder-image';
-      media.append(img);
+      img.alt = HERO_ALT_TEXT;
+      img.loading = 'eager';
+      heroWrapper.append(img);
     } else {
       const placeholder = document.createElement('div');
-      placeholder.className = 'placeholder-image';
-      placeholder.textContent = 'Canadian Trail';
-      media.append(placeholder);
+      placeholder.className = 'title-hero-placeholder';
+      placeholder.setAttribute('role', 'img');
+      placeholder.setAttribute('aria-label', HERO_ALT_TEXT);
+      heroWrapper.append(placeholder);
     }
-    section.append(media);
+
+    const cta = document.createElement('div');
+    cta.className = 'title-cta';
+
+    const header = document.createElement('div');
+    header.className = 'screen-header';
+    header.innerHTML = `
+      <h2 id="title-screen-heading">Pack up, family! We're heading Out There, Eh?</h2>
+      <p>Settle into a cozy Canadian road-trip roguelike. Every journey begins with a full thermos, a hopeful playlist, and a single seed for fate.</p>
+    `;
+    cta.append(header);
 
     const actions = document.createElement('div');
     actions.className = 'inline-chips';
@@ -55,7 +74,7 @@ export default class TitleScreen {
       span.textContent = label;
       actions.append(span);
     });
-    section.append(actions);
+    cta.append(actions);
 
     const buttons = document.createElement('div');
     buttons.className = 'action-buttons';
@@ -82,12 +101,14 @@ export default class TitleScreen {
 
     this.continueButton = continueButton;
 
-    section.append(buttons);
+    cta.append(buttons);
 
     const footer = document.createElement('p');
     footer.className = 'screen-footer';
     footer.textContent = 'Tip: Your seed remembers everything. Share it to challenge friends across the provinces!';
-    section.append(footer);
+    cta.append(footer);
+
+    section.append(heroWrapper, cta);
 
     return section;
   }


### PR DESCRIPTION
## Summary
- add orientation-aware hero art with CTA cluster and title mode body toggles
- refine setup screen with optional brand lockup, safer seed row layout, and larger tap targets
- expand styles for full-viewport title screen, safe-area padding, and mobile accessibility tweaks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc0d7bbbf483209a73db2941b32001